### PR TITLE
fix bytes string to string converting to avoid fake connective warning

### DIFF
--- a/cmds/cmd_package/cmd_package_utils.py
+++ b/cmds/cmd_package/cmd_package_utils.py
@@ -63,11 +63,11 @@ def get_url_from_mirror_server(package_name, package_version):
     """Get the download address from the mirror server based on the package name."""
 
     try:
-        if isinstance(package_name, str):
+        if type(package_name) == bytes:
             if sys.version_info < (3, 0):
                 package_name = str(package_name)
             else:
-                package_name = str(package_name)[2:-1]
+                package_name = str(package_name, encoding='utf-8')
     except Exception as e:
         print('Error message:%s' % e)
         print("\nThe mirror server could not be contacted. Please check your network connection.")


### PR DESCRIPTION
pkg command always print warning message of 'The mirror server could not be contacted. Please check your network connection.', further inspection shows it is not problem of the network connective but the string converting here.

Tested with Python 2.7 and 3.7 using anaconda env.