### PR TITLE
[bug] if no .config use the no mirror

### DIFF
--- a/cmds/cmd_package/cmd_package_update.py
+++ b/cmds/cmd_package/cmd_package_update.py
@@ -138,7 +138,7 @@ def need_using_mirror_download(config_file):
     """default using mirror url to download packages"""
 
     if not os.path.isfile(config_file):
-        return True
+        return False
     elif os.path.isfile(config_file) and find_macro_in_config(config_file, 'SYS_PKGS_DOWNLOAD_ACCELERATE'):
         return True
 


### PR DESCRIPTION
this bug see issue 
https://github.com/supperthomas/supperthomas_doc/issues/248

if mirror access error. the submodule on package will happen error. 
