### PR TITLE
更新API接口地址

### DIFF
--- a/cmds/cmd_package/cmd_package_utils.py
+++ b/cmds/cmd_package/cmd_package_utils.py
@@ -84,7 +84,7 @@ def get_url_from_mirror_server(package_name, package_version):
     payload["packages"][0]['name'] = package_name
 
     try:
-        r = requests.post("http://packages.rt-thread.org/packages/queries", data=json.dumps(payload))
+        r = requests.post("https://api.rt-thread.org/packages/queries", data=json.dumps(payload))
 
         if r.status_code == requests.codes.ok:
             package_info = json.loads(r.text)


### PR DESCRIPTION
- 更新查询接口为https方便全站https
- 更新查询接口为专用加速接口（原接口会继续保持服务1年）