### PR TITLE
增加 pkgs --upgrade-modules 命令

### DIFF
--- a/cmds/cmd_package/__init__.py
+++ b/cmds/cmd_package/__init__.py
@@ -33,7 +33,7 @@ from .cmd_package_list import list_packages
 from .cmd_package_wizard import package_wizard
 from .cmd_package_upgrade import package_upgrade
 from .cmd_package_update import package_update
-
+from .cmd_package_upgrade import package_upgrade_modules
 
 def run_env_cmd(args):
     """Run packages command."""
@@ -50,6 +50,8 @@ def run_env_cmd(args):
         package_upgrade()
     elif args.package_upgrade_force:
         package_upgrade(force_upgrade=True)
+    elif args.package_upgrade_modules:
+        package_upgrade_modules()
     elif args.package_print_env:
         package_print_env()
     else:
@@ -73,12 +75,6 @@ def add_parser(sub):
                         default=False,
                         dest='package_update')
 
-    parser.add_argument('--force-upgrade',
-                        help='force upgrade packages, install or remove the packages by your settings in menuconfig',
-                        action='store_true',
-                        default=False,
-                        dest='package_upgrade_force')
-
     parser.add_argument('--list',
                         help='list target packages',
                         action='store_true',
@@ -96,6 +92,18 @@ def add_parser(sub):
                         action='store_true',
                         default=False,
                         dest='package_upgrade')
+
+    parser.add_argument('--force-upgrade',
+                        help='force upgrade packages, install or remove the packages by your settings in menuconfig',
+                        action='store_true',
+                        default=False,
+                        dest='package_upgrade_force')
+
+    parser.add_argument('--upgrade-modules',
+                        help='upgrade python modules, e.g. requests module',
+                        action='store_true',
+                        default=False,
+                        dest='package_upgrade_modules')
 
     parser.add_argument('--printenv',
                         help='print environmental variables to check',

--- a/cmds/cmd_package/cmd_package_upgrade.py
+++ b/cmds/cmd_package/cmd_package_upgrade.py
@@ -147,3 +147,11 @@ def package_upgrade(force_upgrade=False):
 
     upgrade_packages_index(force_upgrade=force_upgrade)
     upgrade_env_script()
+
+import pip
+from subprocess import call
+from pip._internal.utils.misc import get_installed_distributions
+
+def package_upgrade_modules():
+    for dist in get_installed_distributions():
+        call('pip install --upgrade '+dist.project_name,shell=True)


### PR DESCRIPTION
之前社区经常报告pkgs --update无法下载软件包，其原因是因为requests模块版本过低，本commit增加该命令可以自动升级env所有使用的模块
https://club.rt-thread.org/ask/question/09269075a0b50d8c.html?order=date

![image](https://user-images.githubusercontent.com/34888354/184303654-fb578452-f7e9-419a-837f-d7f9aa3a3c53.png)

史丹利已经帮忙测试过了，更新requests模组之后就可以正常使用pkgs --update 命令了