### PR TITLE
fix the import pip error

### DIFF
--- a/cmds/cmd_package/cmd_package_upgrade.py
+++ b/cmds/cmd_package/cmd_package_upgrade.py
@@ -148,10 +148,12 @@ def package_upgrade(force_upgrade=False):
     upgrade_packages_index(force_upgrade=force_upgrade)
     upgrade_env_script()
 
-import pip
-from subprocess import call
-from pip._internal.utils.misc import get_installed_distributions
-
 def package_upgrade_modules():
-    for dist in get_installed_distributions():
-        call('python -m pip install --upgrade '+dist.project_name,shell=True)
+    try:
+        import pip
+        from subprocess import call
+        from pip._internal.utils.misc import get_installed_distributions
+        for dist in get_installed_distributions():
+            call('python -m pip install --upgrade '+dist.project_name,shell=True)
+    except:
+        print('Fail to upgrade python modules!')


### PR DESCRIPTION
https://github.com/RT-Thread/rt-thread/issues/6267

之前的studio中没有安转相关模块和环境，
采用try的方式，如果没有相关模块，就直接报错，无法升级