### PR TITLE
自动通过IP地址来确认是否使用镜像源

### DIFF
--- a/cmds/Kconfig
+++ b/cmds/Kconfig
@@ -27,10 +27,6 @@ if SYS_CREATE_MDK_IAR_PROJECT
     
 endif
 
-config SYS_PKGS_DOWNLOAD_ACCELERATE
-    bool "Use China Mainland server"
-    default n
-
 config SYS_PKGS_USING_STATISTICS
     bool "Send usage data for improve product"
     default y


### PR DESCRIPTION
Env自动通过IP归属地来确定是否使用gitee镜像源，无需再手动配置：
此种方式优点多多：
1. 国内国外在使用github/gitee上自动确认，不会出现国内莫名其妙走github或者海外莫名其妙走gitee的幺蛾子
2. 在国内使用VPN时，如果采用手动配置的方式，那将依旧走gitee，可能会存在下载失败的问题。而通过IP自动确认的方式，在国内使用VPN时，就会直接走github的镜像源了。