### PR TITLE
取消自动更新env脚本的功能

### DIFF
--- a/cmds/cmd_package/cmd_package_upgrade.py
+++ b/cmds/cmd_package/cmd_package_upgrade.py
@@ -132,7 +132,6 @@ def get_mac_address():
     return ":".join([mac[e:e+2] for e in range(0,11,2)])
 
 def Information_statistics():
-
     env_root = Import('env_root')
 
     # get the .config file from env
@@ -156,8 +155,9 @@ def package_upgrade(force_upgrade=False):
         Information_statistics()
 
     upgrade_packages_index(force_upgrade=force_upgrade)
-    upgrade_env_script(force_upgrade=force_upgrade)
+    # upgrade_env_script(force_upgrade=force_upgrade) # too dangerous to directly upgrade env script
 
+# upgrade python modules
 def package_upgrade_modules():
     try:
         from subprocess import call


### PR DESCRIPTION
该行为有些危险：
env脚本前脚推上去后脚用户就可以收到，如果推送的commits出现问题，无法继续执行的话，用户没有办法更新和补救。

env新版本 伴随env-for-windows仓库发布即可，不需要立刻就更新上去