### PR TITLE
增加find_MDK_EXEC_PATH、find_IAR_EXEC_PATH函数

### DIFF
--- a/cmds/cmd_menuconfig.py
+++ b/cmds/cmd_menuconfig.py
@@ -29,7 +29,7 @@ import os
 import platform
 import re
 from vars import Import
-from .cmd_package.cmd_package_utils import find_macro_in_config
+from .cmd_package.cmd_package_utils import find_bool_macro_in_config
 
 
 def is_pkg_special_config(config_str):
@@ -222,18 +222,18 @@ def cmd(args):
         if not os.path.isfile(fn):
             return
 
-        if find_macro_in_config(fn, 'SYS_AUTO_UPDATE_PKGS'):
+        if find_bool_macro_in_config(fn, 'SYS_AUTO_UPDATE_PKGS'):
             os.system('pkgs --update')
             print("==============================>The packages have been updated completely.")
 
-        if find_macro_in_config(fn, 'SYS_CREATE_MDK_IAR_PROJECT'):
-            if find_macro_in_config(fn, 'SYS_CREATE_MDK4'):
+        if find_bool_macro_in_config(fn, 'SYS_CREATE_MDK_IAR_PROJECT'):
+            if find_bool_macro_in_config(fn, 'SYS_CREATE_MDK4'):
                 os.system('scons --target=mdk4 -s')
                 print("Create mdk4 project done")
-            elif find_macro_in_config(fn, 'SYS_CREATE_MDK5'):
+            elif find_bool_macro_in_config(fn, 'SYS_CREATE_MDK5'):
                 os.system('scons --target=mdk5 -s')
                 print("Create mdk5 project done")
-            elif find_macro_in_config(fn, 'SYS_CREATE_IAR'):
+            elif find_bool_macro_in_config(fn, 'SYS_CREATE_IAR'):
                 os.system('scons --target=iar -s')
                 print("Create iar project done")
 

--- a/cmds/cmd_package/__init__.py
+++ b/cmds/cmd_package/__init__.py
@@ -26,11 +26,21 @@
 # 2020-04-08     SummerGift      Optimize program structure
 #
 
+import os
 from .cmd_package_printenv import package_print_env, package_print_help
 from .cmd_package_list import list_packages
 from .cmd_package_wizard import package_wizard
 from .cmd_package_update import package_update
 from .cmd_package_upgrade import package_upgrade, package_upgrade_modules
+from .cmd_package_utils import find_IAR_EXEC_PATH, find_MDK_EXEC_PATH
+
+iar_exec_path = find_IAR_EXEC_PATH()
+if iar_exec_path:
+    os.environ['RTT_EXEC_PATH'] = iar_exec_path
+
+mdk_exec_path = find_MDK_EXEC_PATH()
+if mdk_exec_path:
+    os.environ['RTT_EXEC_PATH'] = mdk_exec_path
 
 def run_env_cmd(args):
     """Run packages command."""
@@ -117,4 +127,3 @@ def add_parser(sub):
                         dest='package_print_env')
 
     parser.set_defaults(func=run_env_cmd)
-

--- a/cmds/cmd_package/cmd_package_update.py
+++ b/cmds/cmd_package/cmd_package_update.py
@@ -39,7 +39,7 @@ import pkgsdb
 from package import PackageOperation, Bridge_SConscript
 from vars import Import, Export
 from .cmd_package_utils import get_url_from_mirror_server, execute_command, git_pull_repo, user_input, \
-    find_macro_in_config
+    find_bool_macro_in_config
 
 
 def determine_support_chinese(env_root):

--- a/cmds/cmd_package/cmd_package_upgrade.py
+++ b/cmds/cmd_package/cmd_package_upgrade.py
@@ -26,7 +26,7 @@
 import os
 import uuid
 from vars import Import
-from .cmd_package_utils import git_pull_repo, get_url_from_mirror_server, find_macro_in_config
+from .cmd_package_utils import git_pull_repo, get_url_from_mirror_server, find_bool_macro_in_config
 from .cmd_package_update import need_using_mirror_download
 
 try:
@@ -130,12 +130,11 @@ def get_mac_address():
 
 def Information_statistics():
     env_root = Import('env_root')
-
     # get the .config file from env
     env_kconfig_path = os.path.join(env_root, 'tools\scripts\cmds')
     env_config_file = os.path.join(env_kconfig_path, '.config')
 
-    if find_macro_in_config(env_config_file, 'SYS_PKGS_USING_STATISTICS'):
+    if find_bool_macro_in_config(env_config_file, 'SYS_PKGS_USING_STATISTICS'):
         mac_addr = get_mac_address()
         response = requests.get('https://www.rt-thread.org/studio/statistics/api/envuse?userid='+str(mac_addr)+'&username='+str(mac_addr)+'&envversion=1.0&studioversion=2.0&ip=127.0.0.1')
         if response.status_code != 200:

--- a/cmds/cmd_package/cmd_package_utils.py
+++ b/cmds/cmd_package/cmd_package_utils.py
@@ -218,7 +218,7 @@ def find_string_macro_in_config(filename, macro_name):
         return None
 
 
-# return the execution path string or None for failure
+# return IAR execution path string or None for failure
 def find_IAR_EXEC_PATH():
     env_root = Import('env_root')
     # get the .config file from env
@@ -228,7 +228,7 @@ def find_IAR_EXEC_PATH():
     return find_string_macro_in_config(env_config_file, 'SYS_CREATE_IAR_EXEC_PATH')
 
 
-# return the execution path string or None for failure
+# return Keil-MDK execution path string or None for failure
 def find_MDK_EXEC_PATH():
     env_root = Import('env_root')
     # get the .config file from env

--- a/cmds/cmd_package/cmd_package_utils.py
+++ b/cmds/cmd_package/cmd_package_utils.py
@@ -32,7 +32,6 @@ import time
 import shutil
 import requests
 import logging
-from vars import Import
 
 def execute_command(cmd_string, cwd=None, shell=True):
     """Execute the system command at the specified address."""
@@ -220,7 +219,7 @@ def find_string_macro_in_config(filename, macro_name):
 
 # return IAR execution path string or None for failure
 def find_IAR_EXEC_PATH():
-    env_root = Import('env_root')
+    env_root = os.getenv("ENV_ROOT")
     # get the .config file from env
     env_kconfig_path = os.path.join(env_root, 'tools\scripts\cmds')
     env_config_file = os.path.join(env_kconfig_path, '.config')
@@ -230,7 +229,7 @@ def find_IAR_EXEC_PATH():
 
 # return Keil-MDK execution path string or None for failure
 def find_MDK_EXEC_PATH():
-    env_root = Import('env_root')
+    env_root = os.getenv("ENV_ROOT")
     # get the .config file from env
     env_kconfig_path = os.path.join(env_root, 'tools\scripts\cmds')
     env_config_file = os.path.join(env_kconfig_path, '.config')

--- a/statistics.py
+++ b/statistics.py
@@ -52,7 +52,7 @@ def Information_statistics():
                 return
         except Exception as e:
             exit(0)
-    elif os.path.isfile(env_config_file) and cmd_package.find_macro_in_config(env_config_file, 'SYS_PKGS_NOT_USING_STATISTICS'):
+    elif os.path.isfile(env_config_file) and cmd_package.find_bool_macro_in_config(env_config_file, 'SYS_PKGS_NOT_USING_STATISTICS'):
         return True
 
 


### PR DESCRIPTION
通过上述两个函数可以直接获取到 https://github.com/RT-Thread/env/pull/178 新增的Kconfig CONFIG_SYS_CREATE_IAR_EXEC_PATH

勾选自动更新IAR、Keil工程时，可以自动根据Kconfig设置的CONFIG_SYS_CREATE_IAR_EXEC_PATH自动更新IAR 和Keil工程。仅限于自动更新时，自动设置IAR所在路径，使用手动scons --target=iar时，依然走rtconfig.py下的IAR路径。