### PR TITLE
Fix .config file not working on Unix systems

### DIFF
--- a/cmds/cmd_package/cmd_package_update.py
+++ b/cmds/cmd_package/cmd_package_update.py
@@ -158,7 +158,7 @@ def need_using_mirror_download():
         return is_China_ip
 
     server_decision = ""
-    config_file = os.path.join(Import('env_root'), r'tools\scripts\cmds', '.config')
+    config_file = os.path.join(Import('env_root'), 'tools', 'scripts', 'cmds', '.config')
     if os.path.isfile(config_file) and find_bool_macro_in_config(config_file, 'SYS_DOWNLOAD_SERVER_GITHUB'):
         is_China_ip = False # Github which means not China IP
         server_decision = "manually decision"

--- a/cmds/cmd_package/cmd_package_utils.py
+++ b/cmds/cmd_package/cmd_package_utils.py
@@ -222,7 +222,7 @@ def find_string_macro_in_config(filename, macro_name):
 def find_IAR_EXEC_PATH():
     env_root = Import('env_root')
     # get the .config file from env
-    env_kconfig_path = os.path.join(env_root, 'tools\scripts\cmds')
+    env_kconfig_path = os.path.join(env_root, 'tools', 'scripts', 'cmds')
     env_config_file = os.path.join(env_kconfig_path, '.config')
 
     return find_string_macro_in_config(env_config_file, 'SYS_CREATE_IAR_EXEC_PATH')
@@ -232,7 +232,7 @@ def find_IAR_EXEC_PATH():
 def find_MDK_EXEC_PATH():
     env_root = Import('env_root')
     # get the .config file from env
-    env_kconfig_path = os.path.join(env_root, 'tools\scripts\cmds')
+    env_kconfig_path = os.path.join(env_root, 'tools', 'scripts', 'cmds')
     env_config_file = os.path.join(env_kconfig_path, '.config')
 
     return find_string_macro_in_config(env_config_file, 'SYS_CREATE_MDK_EXEC_PATH')

--- a/statistics.py
+++ b/statistics.py
@@ -39,7 +39,7 @@ def get_mac_address():
 
 def Information_statistics():
     # get the .config file from env
-    env_kconfig_path = os.path.join(os.getcwd(), 'tools\\scripts\\cmdscmds')
+    env_kconfig_path = os.path.join(os.getcwd(), 'tools', 'scripts', 'cmds')
     env_config_file = os.path.join(env_kconfig_path, '.config')
 
     mac_addr = get_mac_address()


### PR DESCRIPTION
# 修改内容

修复了 Unix 系统中无法识别到 `.config` 配置文件的问题

# 备注

有同样错误写法的地方如下，但考虑到 Keil 和 IAR 仅支持 Windows 平台，可不修复。

https://github.com/RT-Thread/env/blob/6ec5d9234047da767c0b5b06113303d25d450efa/cmds/cmd_package/cmd_package_utils.py#L222-L238
