### PR TITLE
使用kconfiglib，增加命令行使用env作为入口

### DIFF
--- a/cmds/cmd_package/__init__.py
+++ b/cmds/cmd_package/__init__.py
@@ -60,7 +60,7 @@ def run_env_cmd(args):
 def add_parser(sub):
     """The packages command parser for env."""
 
-    parser = sub.add_parser('pkg', aliases=['package'], help=__doc__, description=__doc__)
+    parser = sub.add_parser('pkg', aliases=['pkgs', 'package'], help=__doc__, description=__doc__)
 
     parser.add_argument('--update',
                         help='update packages, install or remove the packages by your settings in menuconfig',

--- a/cmds/cmd_package/__init__.py
+++ b/cmds/cmd_package/__init__.py
@@ -60,7 +60,7 @@ def run_env_cmd(args):
 def add_parser(sub):
     """The packages command parser for env."""
 
-    parser = sub.add_parser('package', help=__doc__, description=__doc__)
+    parser = sub.add_parser('pkg', aliases=['package'], help=__doc__, description=__doc__)
 
     parser.add_argument('--update',
                         help='update packages, install or remove the packages by your settings in menuconfig',

--- a/cmds/cmd_package/cmd_package_printenv.py
+++ b/cmds/cmd_package/cmd_package_printenv.py
@@ -44,4 +44,4 @@ def package_print_env():
 
 
 def package_print_help():
-    os.system('pkgs -h')
+    os.system('env pkg -h')

--- a/cmds/cmd_sdk.py
+++ b/cmds/cmd_sdk.py
@@ -36,6 +36,8 @@ class MenuConfigArgs:
 
 def cmd(args):
     tools_kconfig_path = os.path.join(Import('env_root'), 'tools')
+    beforepath = os.getcwd()
+    os.chdir(tools_kconfig_path)
 
     from cmds import cmd_menuconfig
     from cmds.cmd_package import list_packages
@@ -64,6 +66,9 @@ def cmd(args):
     with open(os.path.join(tools_kconfig_path, 'sdk_list.json'), 'w', encoding='utf-8') as f:
         json.dump(sdk_packages, f, ensure_ascii=False, indent=4)
 
+    # restore the old directory
+    os.chdir(beforepath)
+    
 def add_parser(sub):
     parser = sub.add_parser('sdk', help=__doc__, description=__doc__)
 

--- a/cmds/cmd_system.py
+++ b/cmds/cmd_system.py
@@ -30,7 +30,7 @@ from vars import Import
 
 
 def cmd(args):
-    packages_root = os.path.join(Import('env_root'), 'packages')
+    packages_root = Import('pkgs_root')
 
     if args.system_update:
         dir_list = os.listdir(packages_root)

--- a/env.ps1
+++ b/env.ps1
@@ -1,4 +1,4 @@
-$VENV_ROOT = "$HOME\.env\tools\rt-env"
+$VENV_ROOT = "$PSScriptRoot\tools\rt-env"
 # rt-env目录是否存在
 if (-not (Test-Path -Path $VENV_ROOT)) {
     Write-Host "Create Python venv for RT-Thread..."
@@ -6,7 +6,7 @@ if (-not (Test-Path -Path $VENV_ROOT)) {
     # 激活python venv
     & "$VENV_ROOT\Scripts\Activate.ps1"
     # 安装env-script
-    pip install "$HOME/.env/tools/scripts"
+    pip install "$PSScriptRoot\tools\scripts"
 }
 else 
 {
@@ -27,9 +27,9 @@ if (Test-Path ".vscode\env.json")
 }
 
 Write-Host "set CC to $RTT_CC_NAME"
-if (Test-Path "$HOME\.env\tools\sdk_list.json")
+if (Test-Path "$PSScriptRoot\tools\sdk_list.json")
 {
-    $sdk_json = Get-Content -Raw -Path "$HOME\.env\tools\sdk_list.json" | ConvertFrom-Json
+    $sdk_json = Get-Content -Raw -Path "$PSScriptRoot\tools\sdk_list.json" | ConvertFrom-Json
     foreach ($sdk in $sdk_json)
     {
         if ($sdk.name -eq $RTT_CC_NAME)
@@ -49,10 +49,10 @@ if (Test-Path "$HOME\.env\tools\sdk_list.json")
         $env:RTT_CC=$RTT_CC_NAME
     }
 
-    $RTT_CC_PATH="$HOME\.env\tools\packages\$RTT_CC_PATH\bin"
+    $RTT_CC_PATH="$PSScriptRoot\tools\packages\$RTT_CC_PATH\bin"
     $env:RTT_EXEC_PATH=$RTT_CC_PATH
 }
 
 $env:HOSTOS="Windows"
-$env:path="$HOME\.env\tools\bin;$RTT_CC_PATH;$env:path"
+$env:path="$PSScriptRoot\tools\bin;$RTT_CC_PATH;$env:path"
 $env:pathext=".PS1;$env:pathext"

--- a/env.py
+++ b/env.py
@@ -153,25 +153,20 @@ def main():
 
     parser = init_argparse()
     args = parser.parse_args()
-    args.func(args)
+
+    if not vars(args):
+        parser.print_help()
+    else:
+        args.func(args)
 
 def menuconfig():
     exec_arg('menuconfig')
 
 def pkgs():
-    exec_arg('package')
+    exec_arg('pkg')
 
 def sdk():
-    # change directory to tools
-    tools_kconfig_path = os.path.join(get_env_root(), 'tools')
-
-    beforepath = os.getcwd()
-    os.chdir(tools_kconfig_path)
-
     exec_arg('sdk')
-
-    # restore the old directory
-    os.chdir(beforepath)
 
 def system():
     exec_arg('system')

--- a/env.py
+++ b/env.py
@@ -64,7 +64,6 @@ def init_logger(env_root):
                         # filename=log_name
                         )
 
-
 def get_env_root():
     env_root = os.getenv("ENV_ROOT")
     if env_root is None:
@@ -76,10 +75,10 @@ def get_env_root():
     return env_root
 
 
-def get_package_root(env_root):
+def get_package_root():
     package_root = os.getenv("PKGS_ROOT")
     if package_root is None:
-        package_root = os.path.join(env_root, 'packages')
+        package_root = os.path.join(get_env_root(), 'packages')
     return package_root
 
 
@@ -105,16 +104,38 @@ def get_bsp_root():
 
     return bsp_root
 
+def get_rtt_root():
+    rtt_root = os.getenv("RTT_ROOT")
+    if rtt_root is None:
+        bsp_root = get_bsp_root()
+        with open(os.path.join(bsp_root, 'Kconfig')) as kconfig:
+            lines = kconfig.readlines()
+        for i in range(len(lines)):
+            if "config RTT_DIR" in lines[i]:
+                break
+        rtt_root = lines[i + 3].strip().split(" ")[1].strip('"')
+        if not os.path.isabs(rtt_root):
+            rtt_root = os.path.join(bsp_root, rtt_root)
+    return rtt_root
+
 def export_environment_variable():
     script_root = os.path.split(os.path.realpath(__file__))[0]
     sys.path = sys.path + [os.path.join(script_root)]
-    bsp_root = get_bsp_root()
     env_root = get_env_root()
-    pkgs_root = get_package_root(env_root)
+    pkgs_root = get_package_root()
+    bsp_root = get_bsp_root()
+    rtt_root = get_rtt_root()
+
+    os.environ["ENV_ROOT"] = env_root
+    os.environ['PKGS_ROOT'] = pkgs_root
+    os.environ['PKGS_DIR'] = pkgs_root
+    os.environ['BSP_DIR'] = bsp_root
+    os.environ['RTT_DIR'] = rtt_root
 
     Export('env_root')
-    Export('bsp_root')
     Export('pkgs_root')
+    Export('bsp_root')
+    Export('rtt_root')
 
 def exec_arg(arg):
     export_environment_variable()

--- a/env.py
+++ b/env.py
@@ -71,7 +71,6 @@ def get_env_root():
             env_root = os.path.join(os.getenv('HOME'), '.env')
         else:
             env_root = os.path.join(os.getenv('USERPROFILE'), '.env')
-
     return env_root
 
 
@@ -104,10 +103,13 @@ def get_bsp_root():
 
     return bsp_root
 
+
 def get_rtt_root():
     rtt_root = os.getenv("RTT_ROOT")
     if rtt_root is None:
         bsp_root = get_bsp_root()
+        if not os.path.exists(os.path.join(bsp_root, 'Kconfig')):
+            return ""
         with open(os.path.join(bsp_root, 'Kconfig')) as kconfig:
             lines = kconfig.readlines()
         for i in range(len(lines)):
@@ -137,6 +139,7 @@ def export_environment_variable():
     Export('bsp_root')
     Export('rtt_root')
 
+
 def exec_arg(arg):
     export_environment_variable()
     init_logger(get_env_root())
@@ -146,6 +149,7 @@ def exec_arg(arg):
     parser = init_argparse()
     args = parser.parse_args()
     args.func(args)
+
 
 def main():
     export_environment_variable()
@@ -159,17 +163,22 @@ def main():
     else:
         args.func(args)
 
+
 def menuconfig():
     exec_arg('menuconfig')
+
 
 def pkgs():
     exec_arg('pkg')
 
+
 def sdk():
     exec_arg('sdk')
 
+
 def system():
     exec_arg('system')
+
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,10 @@ setup(
     entry_points={
         'console_scripts': [
             'env=env.env:main',
-            # 'menuconfig=env.env:menuconfig',
-            # 'pkgs=env.env:pkgs',
-            # 'sdk=env.env:sdk',
-            # 'system=env.env:system',
+            'menuconfig=env.env:menuconfig',
+            'pkgs=env.env:pkgs',
+            'sdk=env.env:sdk',
+            'system=env.env:system',
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
+import platform
 from setuptools import setup, find_packages
+
+if platform.system() == "Windows":
+    need_windows_curses = ["windows-curses"]
+else:
+    need_windows_curses = []
+
 
 setup(
     name='env',
@@ -10,7 +17,7 @@ setup(
     license='Apache License 2.0',
     keywords='rt-thread',
     consoles=[{'env': 'env.py'}],
-    install_requires=['SCons>=4.0.0', 'requests', 'psutil'],
+    install_requires=['SCons>=4.0.0', 'requests', 'psutil', 'kconfiglib'] + need_windows_curses,
     packages=find_packages(include=[], exclude=['cmds', 'sdk', 'test', '__pycache__']),
     data_files= [('Lib/site-packages/env', ['env.py',
                                             'package.py',
@@ -37,10 +44,11 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'console_scripts': [
-            'menuconfig=env.env:menuconfig',
-            'pkgs=env.env:pkgs',
-            'sdk=env.env:sdk',
-            'system=env.env:system',
+            'env=env.env:main',
+            # 'menuconfig=env.env:menuconfig',
+            # 'pkgs=env.env:pkgs',
+            # 'sdk=env.env:sdk',
+            # 'system=env.env:system',
         ]
     }
 )


### PR DESCRIPTION
修改内容包括：
（1）linux和windows都使用kconfiglib，不再使用kconfig-mconf，兼容当前的Kconfig语法（也就是不需要做修改），但新增加的Kconfig建议使用rsource/orsource的语句
（2）命令行使用env作为入口，不再保留menuconfig（防止和kconfiglib冲突）、pkgs、sdk等入口
（3）修改env.ps1，所有路径使用相对env.ps1展开而不是$home/.env，以便支持安装在不同的目录