### PR TITLE
解决sdk指令无法使用（由于运行sdk会切换到env/tools，但是bsp_root没有跟着改变

### DIFF
--- a/cmds/cmd_sdk.py
+++ b/cmds/cmd_sdk.py
@@ -24,7 +24,7 @@
 
 import os
 import json
-from vars import Import
+from vars import Import, Export
 
 '''RT-Thread environment sdk setting'''
 
@@ -35,14 +35,20 @@ class MenuConfigArgs:
     menuconfig_setting = False
 
 def cmd(args):
-    tools_kconfig_path = os.path.join(Import('env_root'), 'tools')
-    beforepath = os.getcwd()
-    os.chdir(tools_kconfig_path)
-
     from cmds import cmd_menuconfig
     from cmds.cmd_package import list_packages
     from cmds.cmd_package import get_packages
     from cmds.cmd_package import package_update
+
+    # change to sdk root directory
+    tools_kconfig_path = os.path.join(Import('env_root'), 'tools')
+    beforepath = os.getcwd()
+    os.chdir(tools_kconfig_path)
+
+    # change bsp root to sdk root
+    bsp_root = tools_kconfig_path
+    before_bsp_root = Import('bsp_root')
+    Export('bsp_root')
 
     args = MenuConfigArgs()
     # do menuconfig
@@ -68,7 +74,12 @@ def cmd(args):
 
     # restore the old directory
     os.chdir(beforepath)
-    
+
+    # restore the old bsp_root
+    bsp_root = before_bsp_root
+    Export('bsp_root')
+
+
 def add_parser(sub):
     parser = sub.add_parser('sdk', help=__doc__, description=__doc__)
 

--- a/env.py
+++ b/env.py
@@ -104,40 +104,21 @@ def get_bsp_root():
     return bsp_root
 
 
-def get_rtt_root():
-    rtt_root = os.getenv("RTT_ROOT")
-    if rtt_root is None:
-        bsp_root = get_bsp_root()
-        if not os.path.exists(os.path.join(bsp_root, 'Kconfig')):
-            return ""
-        with open(os.path.join(bsp_root, 'Kconfig')) as kconfig:
-            lines = kconfig.readlines()
-        for i in range(len(lines)):
-            if "config RTT_DIR" in lines[i]:
-                break
-        rtt_root = lines[i + 3].strip().split(" ")[1].strip('"')
-        if not os.path.isabs(rtt_root):
-            rtt_root = os.path.join(bsp_root, rtt_root)
-    return rtt_root
-
 def export_environment_variable():
     script_root = os.path.split(os.path.realpath(__file__))[0]
     sys.path = sys.path + [os.path.join(script_root)]
     env_root = get_env_root()
     pkgs_root = get_package_root()
     bsp_root = get_bsp_root()
-    rtt_root = get_rtt_root()
 
     os.environ["ENV_ROOT"] = env_root
     os.environ['PKGS_ROOT'] = pkgs_root
     os.environ['PKGS_DIR'] = pkgs_root
     os.environ['BSP_DIR'] = bsp_root
-    os.environ['RTT_DIR'] = rtt_root
 
     Export('env_root')
     Export('pkgs_root')
     Export('bsp_root')
-    Export('rtt_root')
 
 
 def exec_arg(arg):


### PR DESCRIPTION
https://github.com/RT-Thread/env/issues/221

解决sdk指令无法使用（由于运行sdk会切换到env/tools，但是bsp_root没有跟着改变），同时将get_rtt_root函数移到cm_menuconfig.py，每次运行menuconfig的时候重新从环境变量或Kconfig中获取RTT_ROOT

@BernardXiong 