### PR TITLE
modify setup.py, to support pip install env in ubuntu

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,5 @@
 # MarkDown
 *.md     text eol=crlf
 
+*.bat    text eol=crlf
+*.ps1    text eol=crlf

--- a/cmds/cmd_package/cmd_package_printenv.py
+++ b/cmds/cmd_package/cmd_package_printenv.py
@@ -44,4 +44,4 @@ def package_print_env():
 
 
 def package_print_help():
-    os.system('env pkg -h')
+    os.system('pkgs -h')

--- a/env.ps1
+++ b/env.ps1
@@ -1,4 +1,4 @@
-$VENV_ROOT = "$PSScriptRoot\tools\rt-env"
+$VENV_ROOT = "$PSScriptRoot\.venv"
 # rt-env目录是否存在
 if (-not (Test-Path -Path $VENV_ROOT)) {
     Write-Host "Create Python venv for RT-Thread..."
@@ -7,11 +7,9 @@ if (-not (Test-Path -Path $VENV_ROOT)) {
     & "$VENV_ROOT\Scripts\Activate.ps1"
     # 安装env-script
     pip install "$PSScriptRoot\tools\scripts"
-}
-else 
-{
+} else {
     # 激活python venv
     & "$VENV_ROOT\Scripts\Activate.ps1"
 }
 
-$env:pathext=".PS1;$env:pathext"
+$env:pathext = ".PS1;$env:pathext"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 128
+skip-string-normalization = true
+# use-tabs = false

--- a/setup.py
+++ b/setup.py
@@ -1,54 +1,47 @@
-import platform
 from setuptools import setup, find_packages
-
-if platform.system() == "Windows":
-    windows_modules = ['windows-curses', 'psutil']
-else:
-    windows_modules = []
-
 
 setup(
     name='env',
     version='0.0.1',
     description='RT-Thread Env',
-    url='https://github.com/RT-Thread/env',
+    url='https://github.com/RT-Thread/env.git',
     author='RT-Thread Development Team',
     author_email='rt-thread@rt-thread.org',
-    license='Apache License 2.0',
     keywords='rt-thread',
-    consoles=[{'env': 'env.py'}],
-    install_requires=['SCons>=4.0.0', 'requests', 'tqdm', 'kconfiglib'] + windows_modules,
-    packages=find_packages(include=[], exclude=['cmds', 'sdk', 'test', '__pycache__']),
-    data_files= [('Lib/site-packages/env', ['env.py',
-                                            'package.py',
-                                            'archive.py',
-                                            'kconfig.py',
-                                            'statistics.py',
-                                            'vars.py',
-                                            'pkgsdb.py',
-                                            'LICENSE',
-                                            'README.md']),
-                 ('Lib/site-packages/env/cmds', ['cmds/__init__.py',
-                                                 'cmds/cmd_menuconfig.py',
-                                                 'cmds/cmd_sdk.py',
-                                                 'cmds/cmd_system.py',
-                                                 'cmds/Kconfig']),
-                 ('Lib/site-packages/env/cmds/cmd_package', [
-                     'cmds/cmd_package/__init__.py',
-                     'cmds/cmd_package/cmd_package_list.py',
-                     'cmds/cmd_package/cmd_package_printenv.py',
-                     'cmds/cmd_package/cmd_package_update.py',
-                     'cmds/cmd_package/cmd_package_upgrade.py',
-                     'cmds/cmd_package/cmd_package_utils.py',
-                     'cmds/cmd_package/cmd_package_wizard.py'])],
+    license='Apache License 2.0',
+    project_urls={
+        'Github repository': 'https:/github.com/rt-thread/env.git',
+        'User guide': 'https:/github.com/rt-thread/env.git',
+    },
     python_requires='>=3.6',
+    install_requires=[
+        'SCons>=4.0.0',
+        'requests',
+        'psutil',
+        'tqdm',
+        'kconfiglib',
+        'windows-curses; platform_system=="Windows"',
+    ],
+    packages=[
+        'env',
+        'env.cmds',
+        'env.cmds.cmd_package',
+    ],
+    package_dir={
+        'env': '.',
+        'env.cmds': 'cmds',
+        'env.cmds.cmd_package': 'cmds/cmd_package',
+    },
+    package_data={'': ['*.*']},
+    exclude_package_data={'': ['MANIFEST.in']},
+    include_package_data=True,
     entry_points={
         'console_scripts': [
-            'env=env.env:main',
+            'rtt=env.env:main',
             'menuconfig=env.env:menuconfig',
             'pkgs=env.env:pkgs',
             'sdk=env.env:sdk',
             'system=env.env:system',
         ]
-    }
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'rtt=env.env:main',
+            'rt-env=env.env:main',
             'menuconfig=env.env:menuconfig',
             'pkgs=env.env:pkgs',
             'sdk=env.env:sdk',


### PR DESCRIPTION
修改了setup.py，解决了linux下无法正确拷贝env脚本。因为之前所有的py代码是指定了拷贝目录，但是在linux下如果创建了venv，路径是带有python版本的。