### PR TITLE
install_xxx中增加安装kconfiglib依赖项目

### DIFF
--- a/install_macos.sh
+++ b/install_macos.sh
@@ -46,6 +46,11 @@ if ! [ -x "$(command -v tqdm)" ]; then
     $RTT_PYTHON -m pip install tqdm
 fi
 
+if ! [ -x "$(command -v kconfiglib)" ]; then
+    echo "Installing kconfiglib."
+    $RTT_PYTHON -m pip install kconfiglib
+fi
+
 if ! [ -x "$(command -v pyocd)" ]; then
     echo "Installing pyocd."
     $RTT_PYTHON -m pip install -U pyocd

--- a/install_suse.sh
+++ b/install_suse.sh
@@ -3,7 +3,7 @@
 sudo zypper update -y
 
 sudo zypper install python3 python3-pip gcc git ncurses-devel cross-arm-none-gcc11-bootstrap cross-arm-binutils qemu qemu-arm qemu-extra -y
-python3 -m pip install scons requests tqdm
+python3 -m pip install scons requests tqdm kconfiglib
 python3 -m pip install -U pyocd
 
 url=https://raw.githubusercontent.com/RT-Thread/env/master/touch_env.sh

--- a/install_ubuntu.sh
+++ b/install_ubuntu.sh
@@ -4,7 +4,7 @@ sudo apt-get update
 sudo apt-get upgrade -y
 
 sudo apt-get -qq install python3 python3-pip gcc git libncurses5-dev gcc-arm-none-eabi binutils-arm-none-eabi gdb-multiarch qemu qemu-system-arm -y
-python3 -m pip install scons requests tqdm
+python3 -m pip install scons requests tqdm kconfiglib
 python3 -m pip install -U pyocd
 
 url=https://raw.githubusercontent.com/RT-Thread/env/master/touch_env.sh

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -90,6 +90,15 @@ if (!$?) {
     echo "tqdm module has installed. Jump this step."
 }
 
+cmd /c $RTT_PYTHON -m pip list -i $PIP_SOURCE --trusted-host $PIP_HOST | findstr "kconfiglib"  | Out-Null
+if (!$?) {
+    echo "Installing kconfiglib module."
+    cmd /c $RTT_PYTHON -m pip install kconfiglib -i $PIP_SOURCE --trusted-host $PIP_HOST
+} else {
+    echo "kconfiglib module has installed. Jump this step."
+}
+
+
 cmd /c $RTT_PYTHON -m pip list -i $PIP_SOURCE --trusted-host $PIP_HOST | findstr "requests"  | Out-Null
 if (!$?) {
     echo "Installing requests module."


### PR DESCRIPTION
由于rtt/tools移除了kconfiglib文件夹，因此需要再env的install中安装kconfiglib依赖项，具体见https://github.com/RT-Thread/rt-thread/pull/9115