### PR TITLE
解决menuconfig --silent报错，没有正确调用defconfig.main()

### DIFF
--- a/cmds/cmd_menuconfig.py
+++ b/cmds/cmd_menuconfig.py
@@ -233,7 +233,7 @@ def cmd(args):
 
     if args.menuconfig_silent:
         sys.argv = ['defconfig', '--kconfig=Kconfig', '.config']
-        defconfig._main()
+        defconfig.main()
     else:
         sys.argv = ['menuconfig', 'Kconfig']
         menuconfig._main()


### PR DESCRIPTION
menuconfig --silent应该调用defconfig.main()，误写成defconfig._main()