### PR TITLE
fix: git checkout branch error

### DIFF
--- a/cmds/cmd_package/cmd_package_update.py
+++ b/cmds/cmd_package/cmd_package_update.py
@@ -224,7 +224,9 @@ def install_git_package(bsp_package_path, package_name, package_info, package_ur
         logging.info(clone_cmd)
         execute_command(clone_cmd, cwd=bsp_package_path)
 
-        git_check_cmd = 'git checkout -q ' + ver_sha
+        git_check_cmd = (
+            'git remote set-branches origin ' + ver_sha + ';git fetch --depth 1 origin ' + ver_sha + ';git checkout -q ' + ver_sha
+        )
         execute_command(git_check_cmd, cwd=repo_path)
     except Exception as e:
         print('Error message:%s' % e)


### PR DESCRIPTION
RT-Thread: master branch
BSP: ESP32_C3
env: master
cmd:  pkgs --update 
error: pathspec 'rtt-dev' did not match any file(s) known to git

原因分析：git clone 时候使用--depth=1，导致只 clone 最近一次提交的代码。 同步RT-Thread-packages/esp-idf 仓库只同步master分支，checkout 不到 默认的rtt-dev 分支。
修改方案：git remote set-branches origin rtt-dev;git fetch --depth 1 origin rtt-dev;git checkout rtt-dev

自测结果：可以正常 切换到 rtt-dev 分支