### PR TITLE
修正sdk在gitee的链接路径

### DIFF
--- a/touch_env.sh
+++ b/touch_env.sh
@@ -8,7 +8,7 @@ if [ $1 ] && [ $1 = --gitee ]; then
     gitee=1
     DEFAULT_RTT_PACKAGE_URL=https://gitee.com/RT-Thread-Mirror/packages.git
     ENV_URL=https://gitee.com/RT-Thread-Mirror/env.git
-    SDK_URL="https://github.com/RT-Thread-Mirror/sdk.git"
+    SDK_URL="https://gitee.com/RT-Thread-Mirror/sdk.git"
 fi
 
 env_dir=$HOME/.env


### PR DESCRIPTION
当启用gitee时，sdk仓库的路径错了，修正为正确的路径。[TODO: 需要把gitee, sdk仓库变成周期性同步方式]