### PR TITLE
解决sdk_url错误的问题

### DIFF
--- a/touch_env.ps1
+++ b/touch_env.ps1
@@ -6,7 +6,7 @@ if ($args[0] -eq "--gitee") {
     echo "Using gitee service."
     $DEFAULT_RTT_PACKAGE_URL = "https://gitee.com/RT-Thread-Mirror/packages.git"
     $ENV_URL = "https://gitee.com/RT-Thread-Mirror/env.git"
-    $SDK_URL = "https://github.com/RT-Thread-Mirror/sdk.git"
+    $SDK_URL = "https://gitee.com/RT-Thread-Mirror/sdk.git"
 }
 
 $env_dir = "$HOME\.env"

--- a/touch_env.sh
+++ b/touch_env.sh
@@ -8,7 +8,7 @@ if [ $1 ] && [ $1 = --gitee ]; then
     gitee=1
     DEFAULT_RTT_PACKAGE_URL=https://gitee.com/RT-Thread-Mirror/packages.git
     ENV_URL=https://gitee.com/RT-Thread-Mirror/env.git
-    SDK_URL="https://github.com/RT-Thread-Mirror/sdk.git"
+    SDK_URL="https://gitee.com/RT-Thread-Mirror/sdk.git"
 fi
 
 env_dir=$HOME/.env


### PR DESCRIPTION
touch_env.sh和touch_env.ps1中SDK_URL错误写成SDK_URL = "https://github.com/RT-Thread-Mirror/sdk.git"，修改为"https://gitee.com/RT-Thread-Mirror/sdk.git"