### PR TITLE
解决sdk指令无法运行

### DIFF
--- a/cmds/cmd_sdk.py
+++ b/cmds/cmd_sdk.py
@@ -25,26 +25,20 @@
 import os
 import json
 import platform
+import sys
 from vars import Import, Export
 
 '''RT-Thread environment sdk setting'''
 
 
-class MenuConfigArgs:
-    menuconfig_fn = False
-    menuconfig_g = False
-    menuconfig_silent = False
-    menuconfig_setting = False
-
-
 def cmd(args):
-    from cmds import cmd_menuconfig
+    import menuconfig
     from cmds.cmd_package import list_packages
     from cmds.cmd_package import get_packages
     from cmds.cmd_package import package_update
 
     # change to sdk root directory
-    tools_kconfig_path = os.path.join(Import('env_root'), 'tools')
+    tools_kconfig_path = os.path.join(Import('env_root'), 'tools', 'scripts')
     beforepath = os.getcwd()
     os.chdir(tools_kconfig_path)
 
@@ -56,9 +50,9 @@ def cmd(args):
     before_bsp_root = Import('bsp_root')
     Export('bsp_root')
 
-    args = MenuConfigArgs()
     # do menuconfig
-    cmd_menuconfig.cmd(args)
+    sys.argv = ['menuconfig', 'Kconfig']
+    menuconfig._main()
 
     # update package
     package_update()

--- a/touch_env.ps1
+++ b/touch_env.ps1
@@ -27,7 +27,7 @@ if (!(Test-Path -Path $env_dir)) {
     mkdir $env_dir\tools | Out-Null
     git clone $package_url $env_dir/packages/packages --depth=1
     echo 'source "$PKGS_DIR/packages/Kconfig"' | Out-File -FilePath $env_dir/packages/Kconfig -Encoding ASCII
-    git clone $SDK_URL $PKGS_DIR/packages/sdk --depth=1
+    git clone $SDK_URL $env_dir/packages/sdk --depth=1
     git clone $ENV_URL $env_dir/tools/scripts --depth=1
     copy $env_dir/tools/scripts/env.ps1 $env_dir/env.ps1
 } else {


### PR DESCRIPTION
解决由于touch_env.ps1中没有正确安装sdk，以及get_rtt_version函数中bug，目前sdk命令可以运行