### PR TITLE
Add troubleshooting section for Ubuntu 23.04+ installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ PLAN A: Whenever start the ubuntu system, you need to type command `source ~/.en
 
 or PLAN B: open `~/.bashrc` file, and attach the command `source ~/.env/env.sh` at the end of the file. It will be automatically executed when you log in the ubuntu, and you don't need to execute that command any more.
 
+### Troubleshooting
+
+**For Ubuntu 23.04+:** The install script uses `pip install` which may fail on newer Ubuntu versions due to PEP 668 restrictions. If the installation completes but you encounter `ModuleNotFoundError` errors later (e.g., `ModuleNotFoundError: No module named 'tqdm'` or `ModuleNotFoundError: No module named 'kconfiglib'` when using `pkgs` or `scons --menuconfig`), manually install the missing dependencies:
+
+```bash
+sudo apt install python3-tqdm python3-kconfiglib
+```
+
 ### Use Env
 
 Please see: <https://github.com/RT-Thread/rt-thread/blob/master/documentation/env/env.md#bsp-configuration-menuconfig>


### PR DESCRIPTION
## Description

This PR adds a troubleshooting section to the README.md to help users resolve installation issues on Ubuntu 23.04 and later versions.

## Problem

On Ubuntu 23.04+, the installation script may complete successfully, but users may encounter `ModuleNotFoundError` errors when using commands like `pkgs` or `scons --menuconfig`. This is due to PEP 668 restrictions that prevent `pip install` from installing packages into system-wide locations.

## Solution

Added a new "Troubleshooting" section in the README.md that:
- Explains the issue with PEP 668 restrictions on Ubuntu 23.04+
- Provides a clear solution using system package manager (`apt install`)
- Lists the specific packages needed: `python3-tqdm` and `python3-kconfiglib`

## Changes

- Added "Troubleshooting" section after "Prepare Env" section in README.md
- Includes instructions for Ubuntu 23.04+ users to manually install missing dependencies

## Testing

- Verified the documentation format and clarity
- Confirmed the solution works on Ubuntu 23.04+ systems

## Related Issues

This addresses installation issues on newer Ubuntu versions where PEP 668 restrictions cause module import errors after installation.

