### PR TITLE
fix(windows): avoid wget dependency in install script

### DIFF
--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -64,6 +64,22 @@ function Ensure-SystemPathContains([string] $PathToAdd) {
     }
 }
 
+function Ensure-UserEnvVar([string] $Name, [string] $Value) {
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return
+    }
+
+    $currentValue = [Environment]::GetEnvironmentVariable($Name, "User")
+    if ($currentValue -ne $Value) {
+        [Environment]::SetEnvironmentVariable($Name, $Value, "User")
+        echo "Set user environment variable $Name=$Value"
+    } else {
+        echo "User environment variable $Name already set."
+    }
+
+    Set-Item -Path "Env:$Name" -Value $Value
+}
+
 foreach ($p_cmd in ("python3", "python", "py")) {
     cmd /c $p_cmd --version | findstr "Python" | Out-Null
     if (!$?) { continue }
@@ -201,6 +217,19 @@ if (Test-Command arm-none-eabi-gcc) {
     }
 
     Ensure-SystemPathContains $ARM_GNU_BIN
+}
+
+$rttExecPath = ""
+if (Test-Path -Path $ARM_GNU_BIN) {
+    $rttExecPath = $ARM_GNU_BIN
+} elseif (Test-Command arm-none-eabi-gcc) {
+    $rttExecPath = Split-Path -Parent (Get-Command arm-none-eabi-gcc).Source
+}
+
+if (![string]::IsNullOrWhiteSpace($rttExecPath)) {
+    Ensure-UserEnvVar "RTT_EXEC_PATH" $rttExecPath
+} else {
+    echo "Warning: arm-none-eabi-gcc not found, skip setting RTT_EXEC_PATH."
 }
 
 $url = "https://raw.githubusercontent.com/RT-Thread/env/master/touch_env.ps1"

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -1,5 +1,10 @@
 
 $RTT_PYTHON = "python"
+$ARM_GNU_VERSION = "14.3.rel1"
+$ARM_GNU_INSTALLER = "arm-gnu-toolchain-$ARM_GNU_VERSION-mingw-w64-i686-arm-none-eabi.exe"
+$ARM_GNU_URL = "https://developer.arm.com/-/media/Files/downloads/gnu/$ARM_GNU_VERSION/binrel/$ARM_GNU_INSTALLER"
+$ARM_GNU_DIR = "C:\Program Files (x86)\Arm GNU Toolchain arm-none-eabi\14.3 rel1"
+$ARM_GNU_BIN = Join-Path $ARM_GNU_DIR "bin"
 
 function Test-Command( [string] $CommandName ) {
     (Get-Command $CommandName -ErrorAction SilentlyContinue) -ne $null
@@ -23,6 +28,40 @@ function Download-File([string] $Url, [string] $OutFile) {
     }
 
     return $false
+}
+
+function Ensure-SystemPathContains([string] $PathToAdd) {
+    if (!(Test-Path -Path $PathToAdd)) {
+        return
+    }
+
+    $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+    if ([string]::IsNullOrEmpty($machinePath)) {
+        $machinePath = ""
+    }
+
+    $machineItems = $machinePath -split ";" | Where-Object { $_ -ne "" }
+    if ($machineItems -notcontains $PathToAdd) {
+        $newMachinePath = if ($machinePath.TrimEnd(";")) {
+            $machinePath.TrimEnd(";") + ";" + $PathToAdd
+        } else {
+            $PathToAdd
+        }
+
+        try {
+            [Environment]::SetEnvironmentVariable("Path", $newMachinePath, "Machine")
+            echo "Add ARM GCC bin to system PATH: $PathToAdd"
+        } catch {
+            echo "Warning: failed to update system PATH. Please run PowerShell as Administrator."
+        }
+    } else {
+        echo "ARM GCC bin already exists in system PATH."
+    }
+
+    $procItems = $env:Path -split ";" | Where-Object { $_ -ne "" }
+    if ($procItems -notcontains $PathToAdd) {
+        $env:Path = $env:Path.TrimEnd(";") + ";" + $PathToAdd
+    }
 }
 
 foreach ($p_cmd in ("python3", "python", "py")) {
@@ -139,6 +178,29 @@ if (!$?) {
     cmd /c $RTT_PYTHON -m pip install psutil -i $PIP_SOURCE --trusted-host $PIP_HOST
 } else {
     echo "psutil module has installed. Jump this step."
+}
+
+if (Test-Command arm-none-eabi-gcc) {
+    echo "ARM GNU GCC has installed. Jump this step."
+} else {
+    if (!(Test-Path -Path $ARM_GNU_DIR)) {
+        echo "Downloading ARM GNU Toolchain $ARM_GNU_VERSION."
+        if (!(Download-File $ARM_GNU_URL $ARM_GNU_INSTALLER)) {
+            echo "Download ARM GNU Toolchain installer failed."
+            exit 1
+        }
+
+        echo "Installing ARM GNU Toolchain $ARM_GNU_VERSION."
+        $proc = Start-Process -FilePath ".\$ARM_GNU_INSTALLER" -ArgumentList "/S", "/P", "/R" -Wait -PassThru
+        if ($proc.ExitCode -ne 0) {
+            echo "Install ARM GNU Toolchain failed, exit code: $($proc.ExitCode)"
+            exit 1
+        }
+    } else {
+        echo "Found ARM GNU Toolchain directory: $ARM_GNU_DIR"
+    }
+
+    Ensure-SystemPathContains $ARM_GNU_BIN
 }
 
 $url = "https://raw.githubusercontent.com/RT-Thread/env/master/touch_env.ps1"

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -5,6 +5,26 @@ function Test-Command( [string] $CommandName ) {
     (Get-Command $CommandName -ErrorAction SilentlyContinue) -ne $null
 }
 
+function Download-File([string] $Url, [string] $OutFile) {
+    if (Test-Command "Invoke-WebRequest") {
+        try {
+            Invoke-WebRequest -Uri $Url -OutFile $OutFile
+            if (Test-Path -Path $OutFile) { return $true }
+        } catch {
+            echo "Invoke-WebRequest download failed: $Url"
+        }
+    }
+
+    if (Test-Command "curl.exe") {
+        cmd /c curl.exe -L $Url -o $OutFile | Out-Null
+        if ($LASTEXITCODE -eq 0 -and (Test-Path -Path $OutFile)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 foreach ($p_cmd in ("python3", "python", "py")) {
     cmd /c $p_cmd --version | findstr "Python" | Out-Null
     if (!$?) { continue }
@@ -16,7 +36,10 @@ cmd /c $RTT_PYTHON --version | findstr "Python" | Out-Null
 if (!$?) {
     echo "Python is not installed. Will install python 3.11.2."
     echo "Downloading Python."
-    wget -O Python_setup.exe https://www.python.org/ftp/python/3.11.2/python-3.11.2.exe
+    if (!(Download-File "https://www.python.org/ftp/python/3.11.2/python-3.11.2.exe" "Python_setup.exe")) {
+        echo "Download Python installer failed."
+        exit 1
+    }
     echo "Installing Python."
     if (Test-Path -Path "D:\") {
         cmd /c Python_setup.exe /quiet TargetDir=D:\Progrem\Python311 InstallAllUsers=1 PrependPath=1 Include_test=0
@@ -42,7 +65,10 @@ if (!(Test-Command git)) {
     if (!$?) {
         echo "Can't find winget cmd, Will install git 2.39.2."
         echo "downloading git."
-        wget -O Git64.exe $git_url
+        if (!(Download-File $git_url "Git64.exe")) {
+            echo "Download Git installer failed."
+            exit 1
+        }
         echo "Please install git. when install done, close the current terminal and run this script again."
         cmd /c Git64.exe /quiet PrependPath=1
         exit
@@ -120,9 +146,12 @@ if ($args[0] -eq "--gitee") {
     $url = "https://gitee.com/RT-Thread-Mirror/env/raw/master/touch_env.ps1"
 }
 
-wget $url -O touch_env.ps1
+if (!(Download-File $url "touch_env.ps1")) {
+    echo "Download touch_env.ps1 failed. Please check network/proxy and retry."
+    exit 1
+}
 echo "run touch_env.ps1"
-./touch_env.ps1 $args[0]
+& .\touch_env.ps1 $args[0]
 
 if ($args.Count -ge 2 -and $args[1] -eq "-y") {
     echo "Windows Env environment installment has finished. (auto mode, no pause)"


### PR DESCRIPTION
  - 主要修复：
      1. 去掉 wget 依赖，改为 Invoke-WebRequest + curl.exe 兜底下载
      2. 下载失败时明确报错并 exit 1
      3. ./touch_env.ps1 改为 PowerShell 兼容调用 & .\touch_env.ps1