### PR TITLE
Feature/plugin command multi instance

### DIFF
--- a/plugins/dispatcher.py
+++ b/plugins/dispatcher.py
@@ -72,7 +72,9 @@ def dispatch(command_name, argv, env_root=None, workspace_root=None):
         if owner is None:
             raise DispatchError("plugin command is not registered: %s" % command_name)
 
-    with FileLock(paths.runtime_lock(owner)):
+    # Commands share the runtime lease so independent terminal invocations can
+    # run concurrently. Lifecycle operations still acquire it exclusively.
+    with FileLock(paths.runtime_lock(owner), shared=True):
         with store.lock():
             state = store.load()
             plugin_id, version, command, permissions, site_packages = _load_command(state, command_name, paths)

--- a/plugins/store.py
+++ b/plugins/store.py
@@ -11,31 +11,89 @@ from .errors import StateError
 STATE_SCHEMA_VERSION = 1
 
 
+if os.name == 'nt':
+    import ctypes
+    from ctypes import wintypes
+
+    class _Overlapped(ctypes.Structure):
+        _fields_ = [
+            ('internal', ctypes.c_void_p),
+            ('internal_high', ctypes.c_void_p),
+            ('offset', wintypes.DWORD),
+            ('offset_high', wintypes.DWORD),
+            ('event', wintypes.HANDLE),
+        ]
+
+    _LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
+
+
+def _lock_windows(handle, shared):
+    import msvcrt
+
+    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    kernel32.LockFileEx.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_Overlapped),
+    ]
+    kernel32.LockFileEx.restype = wintypes.BOOL
+    overlapped = _Overlapped()
+    flags = 0 if shared else _LOCKFILE_EXCLUSIVE_LOCK
+    file_handle = wintypes.HANDLE(msvcrt.get_osfhandle(handle))
+    if not kernel32.LockFileEx(file_handle, flags, 0, 1, 0, ctypes.byref(overlapped)):
+        raise ctypes.WinError(ctypes.get_last_error())
+    return kernel32, file_handle, overlapped
+
+
+def _unlock_windows(lock):
+    kernel32, file_handle, overlapped = lock
+    kernel32.UnlockFileEx.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_Overlapped),
+    ]
+    kernel32.UnlockFileEx.restype = wintypes.BOOL
+    if not kernel32.UnlockFileEx(file_handle, 0, 1, 0, ctypes.byref(overlapped)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
 def empty_state():
     return {'schema_version': STATE_SCHEMA_VERSION, 'plugins': {}, 'commands': {}}
 
 
 class FileLock(object):
-    def __init__(self, path):
+    def __init__(self, path, shared=False):
         self.path = path
+        self.shared = bool(shared)
         self.handle = None
+        self._windows_lock = None
 
     def __enter__(self):
         os.makedirs(os.path.dirname(self.path), exist_ok=True)
-        self.handle = open(self.path, 'a+b')
-        self.handle.seek(0)
-        if os.name == 'nt':
-            import msvcrt
+        try:
+            self.handle = open(self.path, 'a+b')
+            self.handle.seek(0)
+            if os.name == 'nt':
+                if os.path.getsize(self.path) == 0:
+                    self.handle.write(b'0')
+                    self.handle.flush()
+                    self.handle.seek(0)
+                self._windows_lock = _lock_windows(self.handle.fileno(), self.shared)
+            else:
+                import fcntl
 
-            if os.path.getsize(self.path) == 0:
-                self.handle.write(b'0')
-                self.handle.flush()
-                self.handle.seek(0)
-            msvcrt.locking(self.handle.fileno(), msvcrt.LK_LOCK, 1)
-        else:
-            import fcntl
-
-            fcntl.flock(self.handle.fileno(), fcntl.LOCK_EX)
+                mode = fcntl.LOCK_SH if self.shared else fcntl.LOCK_EX
+                fcntl.flock(self.handle.fileno(), mode)
+        except Exception:
+            if self.handle is not None:
+                self.handle.close()
+                self.handle = None
+            raise
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -44,9 +102,7 @@ class FileLock(object):
         try:
             self.handle.seek(0)
             if os.name == 'nt':
-                import msvcrt
-
-                msvcrt.locking(self.handle.fileno(), msvcrt.LK_UNLCK, 1)
+                _unlock_windows(self._windows_lock)
             else:
                 import fcntl
 
@@ -54,6 +110,7 @@ class FileLock(object):
         finally:
             self.handle.close()
             self.handle = None
+            self._windows_lock = None
 
 
 class StateStore(object):

--- a/plugins/tests/test_lifecycle.py
+++ b/plugins/tests/test_lifecycle.py
@@ -245,6 +245,76 @@ class LifecycleTest(unittest.TestCase):
         self.assertGreater(elapsed, 0.5)
         self.assertFalse(os.path.exists(self.launcher()))
 
+    def test_command_allows_multiple_instances(self):
+        project = copy_project(os.path.join(EXAMPLES, 'hello-1.0.0'), os.path.join(self.temporary.name, 'parallel'))
+        source_path = os.path.join(project, 'src', 'env_plugin_hello', 'cli.py')
+        with open(source_path, 'w', encoding='utf-8') as source:
+            source.write(
+                'import os\n'
+                'import time\n\n'
+                'def health_check():\n'
+                '    return 0\n\n'
+                'def main(argv, context):\n'
+                '    marker = os.path.join(context.data_dir, "started-" + argv[0])\n'
+                '    with open(marker, "w") as started:\n'
+                '        started.write("started")\n'
+                '    release = os.path.join(context.data_dir, "release")\n'
+                '    while not os.path.exists(release):\n'
+                '        time.sleep(0.01)\n'
+                '    print(argv[0])\n'
+                '    return 0\n'
+            )
+        package = build_example_project(project, self.packages)
+        self.service.install(package, allow_unsigned=True)
+        marker_root = os.path.join(
+            self.env_root,
+            'var',
+            'plugins',
+            'data',
+            'org.rt-thread.examples.hello',
+        )
+        first = subprocess.Popen(
+            [self.launcher(), 'first'],
+            cwd=self.temporary.name,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        try:
+            self._wait_for_path(os.path.join(marker_root, 'started-first'))
+            second = subprocess.Popen(
+                [self.launcher(), 'second'],
+                cwd=self.temporary.name,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+            )
+            try:
+                self._wait_for_path(os.path.join(marker_root, 'started-second'))
+                self.assertIsNone(first.poll(), 'the first command instance was serialized')
+                with open(os.path.join(marker_root, 'release'), 'w') as release:
+                    release.write('release')
+                first_stdout, first_stderr = first.communicate(timeout=2.0)
+                second_stdout, second_stderr = second.communicate(timeout=2.0)
+            finally:
+                if second.poll() is None:
+                    second.kill()
+                    second.communicate()
+            self.assertEqual(first.returncode, 0, first_stderr)
+            self.assertEqual(second.returncode, 0, second_stderr)
+            self.assertEqual(first_stdout.strip(), 'first')
+            self.assertEqual(second_stdout.strip(), 'second')
+        finally:
+            if first.poll() is None:
+                first.kill()
+                first.communicate()
+
+    def _wait_for_path(self, path):
+        deadline = time.monotonic() + 5.0
+        while not os.path.exists(path) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(os.path.exists(path), 'expected marker was not created: %s' % path)
+
 
 def build_example_project(project, output):
     from plugins.epack.builder import build_project


### PR DESCRIPTION
## Summary
- allow multiple terminal instances of the same Env plugin command to run concurrently
- keep plugin lifecycle operations exclusive so uninstall waits for active commands
- add native Windows shared/exclusive file locking and a concurrency regression test

## Validation
- `python -m unittest plugins.tests.test_lifecycle -v` (13 passed)
- `python -m py_compile plugins/store.py plugins/dispatcher.py plugins/installer.py plugins/tests/test_lifecycle.py`
- `git diff --check`