### PR TITLE
Add plugin backend services and harden package update handling

### DIFF
--- a/cmds/cmd_package/cmd_package_update.py
+++ b/cmds/cmd_package/cmd_package_update.py
@@ -31,6 +31,10 @@ import os
 import platform
 import shutil
 import time
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 import requests
 
@@ -43,6 +47,8 @@ from .cmd_package_utils import (
     get_url_from_mirror_server,
     execute_command,
     git_pull_repo,
+    is_env_repository,
+    get_git_root_path as resolve_git_root_path,
     user_input,
     find_bool_macro_in_config,
 )
@@ -125,28 +131,18 @@ Return('objs')
 
 
 def _get_git_restore_url(package_obj, ver):
-    """Return a suitable git URL to restore remote.origin.url.
+    """Return the version-specific Git URL used to clone a package.
 
-    Prefer the per-version URL if it ends with '.git'. Otherwise, fall back to
-    the 'repository' field (appending '.git' when necessary). Return None when
-    no suitable git URL can be determined.
+    The package ``repository`` field is descriptive metadata and may point to
+    a project homepage. It must never be converted into a Git remote URL.
     """
     try:
         url = package_obj.get_url(ver)
     except Exception:
         url = None
 
-    if url and isinstance(url, str) and url.endswith('.git'):
+    if url and is_git_url(url):
         return url
-
-    repo = None
-    try:
-        repo = package_obj.pkg.get('repository') if package_obj and package_obj.pkg else None
-    except Exception:
-        repo = None
-
-    if repo and isinstance(repo, str):
-        return repo if repo.endswith('.git') else repo + '.git'
 
     return None
 
@@ -466,11 +462,23 @@ def need_using_mirror_download():
 
 
 def is_git_url(package_url):
-    return package_url.endswith('.git')
+    if not isinstance(package_url, str):
+        return False
+
+    package_url = package_url.strip()
+    if not package_url.endswith('.git'):
+        return False
+
+    parsed = urlparse(package_url)
+    return parsed.scheme in ('http', 'https', 'git', 'ssh') and bool(parsed.netloc)
 
 
 def update_submodule(repo_path, use_esp_mirror):
     print(repo_path)
+    if is_env_repository(repo_path):
+        logging.warning('Refusing submodule operations in the Env repository: %s', repo_path)
+        return
+
     # If there is a .gitmodules file in the package, prepare to update submodule.
     gitmodules_path = os.path.join(repo_path, '.gitmodules')
     if os.path.isfile(gitmodules_path):
@@ -536,9 +544,11 @@ def install_git_package(
 
     # change upstream back to origin url when applicable
     # only restore when a valid git URL is available
-    if upstream_changed and url_origin and str(url_origin).endswith('.git'):
+    if upstream_changed and url_origin and is_git_url(url_origin) and not is_env_repository(repo_path):
         cmd = 'git remote set-url origin ' + url_origin
         execute_command(cmd, cwd=repo_path)
+    elif upstream_changed and is_env_repository(repo_path):
+        logging.warning('Refusing to change the Env repository remote: %s', repo_path)
 
     # If there is a .gitmodules file in the package, prepare to update submodule.
     gitmodules_path = os.path.join(repo_path, '.gitmodules')
@@ -711,6 +721,10 @@ def get_package_folder(origin_path, version):
 
 
 def git_cmd_exec(cmd, cwd):
+    if is_env_repository(cwd):
+        logging.warning('Refusing Git command in the Env repository: %s', cmd)
+        return
+
     try:
         execute_command(cmd, cwd=cwd)
     except Exception as e:
@@ -743,7 +757,6 @@ def update_latest_packages(sys_value):
         read_back_pkgs_json = json.load(f)
 
     for pkg in read_back_pkgs_json:
-        right_path_flag = True
         package = PackageOperation()
         pkg_path = pkg['path']
         if pkg_path[0] == '/' or pkg_path[0] == '\\':
@@ -756,11 +769,23 @@ def update_latest_packages(sys_value):
         # Find out the packages which version is 'latest'
         if pkg['ver'] == "latest_version" or pkg['ver'] == "latest":
             package_url = package.get_url(pkg['ver'])
+            if not is_git_url(package_url):
+                logging.info('Skip Git update for non-Git package %s: %s', pkgs_name_in_json, package_url)
+                continue
+
             hal_sdk_package_path = get_hal_sdk_package_path(bsp_root, pkgs_name_in_json, pkg['ver'])
             if is_hal_sdk_package(pkg) and hal_sdk_package_path and package_url and is_git_url(package_url):
                 repo_path = hal_sdk_package_path
             else:
                 repo_path = get_bsp_package_path(bsp_packages_path, pkgs_name_in_json, pkg['ver'])
+
+            get_git_root = get_git_root_path(repo_path)
+            if not get_git_root or not _same_path(repo_path, get_git_root):
+                logging.warning('Skip Git update outside a package repository: %s', repo_path)
+                continue
+            if is_env_repository(repo_path):
+                logging.warning('Skip Git update for the Env repository: %s', repo_path)
+                continue
 
             # noinspection PyBroadException
             try:
@@ -771,29 +796,12 @@ def update_latest_packages(sys_value):
                     # Change repo's upstream address.
                     mirror_url = get_url_from_mirror_server(payload_pkgs_name_in_json, pkg['ver'])
 
-                    # if git root is same as repo path, then change the upstream
-                    get_git_root = get_git_root_path(repo_path)
-                    if get_git_root:
-                        if os.path.normcase(repo_path) == os.path.normcase(get_git_root):
-                            if mirror_url[0] is not None:
-                                cmd = 'git remote set-url origin ' + mirror_url[0]
-                                git_cmd_exec(cmd, repo_path)
-                        else:
-                            print("\n==============================> updating")
-                            print("Package path: %s" % repo_path)
-                            print("Git root: %s" % get_git_root)
-                            print("Error: Not currently in a git root directory, cannot switch upstream.\n")
-                            right_path_flag = False
-                            result = False
-                    else:
-                        right_path_flag = False
-                        result = False
+                    if mirror_url[0] and is_git_url(mirror_url[0]):
+                        cmd = 'git remote set-url origin ' + mirror_url[0]
+                        git_cmd_exec(cmd, repo_path)
 
             except Exception as e:
                 logging.warning("Failed to connect to the mirror server, using non-mirror server to update.")
-
-            if not right_path_flag:
-                continue
 
             # Update the package repository from upstream.
             git_pull_repo(repo_path)
@@ -803,11 +811,13 @@ def update_latest_packages(sys_value):
 
             # recover origin url to a proper git URL from package info
             restore_url = _get_git_restore_url(package, pkg['ver'])
-            if restore_url:
+            if restore_url and not is_env_repository(repo_path):
                 cmd = 'git remote set-url origin ' + restore_url
                 git_cmd_exec(cmd, repo_path)
+            elif is_env_repository(repo_path):
+                logging.warning('Refusing to restore the Env repository remote: %s', repo_path)
             else:
-                print("Can't restore origin: no git URL found for package in %s" % pkg_path)
+                print("Can't restore origin: no version-specific Git URL found for package in %s" % pkg_path)
 
             print("==============================>  %s update done\n" % pkgs_name_in_json)
 
@@ -815,24 +825,14 @@ def update_latest_packages(sys_value):
 
 
 def get_git_root_path(repo_path):
-    if os.path.isdir(repo_path):
-        try:
-            before = os.getcwd()
-            os.chdir(repo_path)
-            result = os.popen("git rev-parse --show-toplevel")
-            result = result.read()
-            for line in result.splitlines()[:5]:
-                get_git_root = line
-                break
-            os.chdir(before)
-            return get_git_root
-        except Exception as e:
-            logging.warning("Error message : %s" % e)
-            return None
-    else:
+    result = resolve_git_root_path(repo_path)
+    if result:
+        return result
+
+    if not os.path.isdir(repo_path):
         logging.warning("Missing path {0}".format(repo_path))
         logging.warning("If you manage this package manually, Env tool will not update it.")
-        return None
+    return None
 
 
 def pre_package_update():

--- a/cmds/cmd_package/cmd_package_upgrade.py
+++ b/cmds/cmd_package/cmd_package_upgrade.py
@@ -26,7 +26,7 @@
 import os
 import uuid
 from vars import Import
-from .cmd_package_utils import git_pull_repo, get_url_from_mirror_server, find_bool_macro_in_config
+from .cmd_package_utils import execute_command, git_pull_repo, get_url_from_mirror_server, find_bool_macro_in_config
 from .cmd_package_update import need_using_mirror_download
 
 try:
@@ -65,15 +65,12 @@ def upgrade_packages_index(force_upgrade=False):
 
     if not os.path.isdir(pkgs_path):
         cmd = 'git clone ' + git_repo + ' ' + pkgs_path + ' --depth=1'
-        os.system(cmd)
+        execute_command(cmd, cwd=packages_root)
         print("upgrade from :%s" % (git_repo.encode("utf-8")))
     else:
         if force_upgrade:
-            cwd = os.getcwd()
-            os.chdir(pkgs_path)
-            os.system('git fetch --all')
-            os.system('git reset --hard origin/master')
-            os.chdir(cwd)
+            execute_command('git fetch --all', cwd=pkgs_path)
+            execute_command('git reset --hard origin/master', cwd=pkgs_path)
         print("Begin to upgrade env packages.")
         git_pull_repo(pkgs_path, git_repo)
         print("==============================>  Env packages upgrade done \n")
@@ -88,11 +85,8 @@ def upgrade_packages_index(force_upgrade=False):
             if os.path.isdir(os.path.join(package_path, '.git')):
                 print("Begin to upgrade %s." % filename)
                 if force_upgrade:
-                    cwd = os.getcwd()
-                    os.chdir(package_path)
-                    os.system('git fetch --all')
-                    os.system('git reset --hard origin/master')
-                    os.chdir(cwd)
+                    execute_command('git fetch --all', cwd=package_path)
+                    execute_command('git reset --hard origin/master', cwd=package_path)
                 git_pull_repo(package_path)
                 print("==============================>  Env %s update done \n" % filename)
 
@@ -115,11 +109,8 @@ def upgrade_env_script(force_upgrade=False):
 
     env_scripts_root = os.path.join(env_root, 'tools', 'scripts')
     if force_upgrade:
-        cwd = os.getcwd()
-        os.chdir(env_scripts_root)
-        os.system('git fetch --all')
-        os.system('git reset --hard origin/master')
-        os.chdir(cwd)
+        execute_command('git fetch --all', cwd=env_scripts_root)
+        execute_command('git reset --hard origin/master', cwd=env_scripts_root)
     print("Begin to upgrade env scripts.")
     git_pull_repo(env_scripts_root, env_scripts_repo)
     print("==============================>  Env scripts upgrade done \n")

--- a/cmds/cmd_package/cmd_package_utils.py
+++ b/cmds/cmd_package/cmd_package_utils.py
@@ -26,6 +26,7 @@
 import json
 import os
 import platform
+import shlex
 import subprocess
 import sys
 import time
@@ -35,8 +36,135 @@ import logging
 from vars import Import
 
 
+def get_git_root_path(repo_path):
+    """Return the Git worktree root containing repo_path, if any."""
+    if not repo_path or not os.path.isdir(repo_path):
+        return None
+
+    try:
+        process = subprocess.Popen(
+            ['git', '-C', os.path.abspath(repo_path), 'rev-parse', '--show-toplevel'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        output = process.communicate()[0]
+        if process.returncode != 0:
+            return None
+        if not isinstance(output, str):
+            output = output.decode('utf-8', errors='replace')
+        return output.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def is_env_repository(repo_path):
+    """Return True when repo_path resolves to the Env repository itself."""
+    try:
+        env_root = Import('env_root')
+    except (KeyError, TypeError):
+        env_root = None
+
+    if not env_root:
+        env_root = os.environ.get('ENV_ROOT')
+    if not env_root:
+        home = os.environ.get('HOME') or os.environ.get('USERPROFILE')
+        if home:
+            env_root = os.path.join(home, '.env')
+    if not env_root:
+        return False
+
+    git_root = get_git_root_path(repo_path)
+    if not git_root:
+        return False
+
+    git_root = os.path.realpath(git_root)
+    env_root = os.path.realpath(env_root)
+    env_repository_roots = (env_root, os.path.join(env_root, 'tools', 'scripts'))
+    return any(git_root == root for root in map(os.path.realpath, env_repository_roots))
+
+
+def _git_config_command_targets(command, cwd=None):
+    """Yield working-tree paths for Git commands that may write config.
+
+    Git global options can appear between ``git`` and the subcommand, and
+    ``-C`` can select a repository unrelated to the process working directory.
+    Tokenizing the command keeps the Env-repository guard effective for both
+    forms instead of relying on a fragile substring match.
+    """
+    try:
+        tokens = shlex.split(str(command), posix=(os.name != 'nt'))
+    except ValueError:
+        tokens = str(command).split()
+
+    default_cwd = os.path.abspath(cwd or os.getcwd())
+    config_commands = ('config', 'remote', 'submodule')
+
+    for index, token in enumerate(tokens):
+        if os.path.basename(token).lower() not in ('git', 'git.exe'):
+            continue
+
+        target_cwd = default_cwd
+        git_dir = None
+        cursor = index + 1
+        while cursor < len(tokens):
+            option = tokens[cursor]
+            if option == '-C' and cursor + 1 < len(tokens):
+                target_cwd = tokens[cursor + 1]
+                cursor += 2
+            elif option.startswith('-C') and len(option) > 2:
+                target_cwd = option[2:]
+                cursor += 1
+            elif option == '--work-tree' and cursor + 1 < len(tokens):
+                target_cwd = tokens[cursor + 1]
+                cursor += 2
+            elif option.startswith('--work-tree='):
+                target_cwd = option.split('=', 1)[1]
+                cursor += 1
+            elif option == '--git-dir' and cursor + 1 < len(tokens):
+                git_dir = tokens[cursor + 1]
+                cursor += 2
+            elif option.startswith('--git-dir='):
+                git_dir = option.split('=', 1)[1]
+                cursor += 1
+            elif option in ('-c', '--config-env') and cursor + 1 < len(tokens):
+                cursor += 2
+            elif option.startswith('-'):
+                cursor += 1
+            else:
+                break
+
+        if cursor >= len(tokens) or tokens[cursor].lower() not in config_commands:
+            continue
+
+        target_cwd = target_cwd.strip()
+        if len(target_cwd) >= 2 and target_cwd[0] == target_cwd[-1] and target_cwd[0] in ('"', "'"):
+            target_cwd = target_cwd[1:-1]
+        if not os.path.isabs(target_cwd):
+            target_cwd = os.path.join(default_cwd, target_cwd)
+        target_cwd = os.path.abspath(target_cwd)
+
+        if git_dir:
+            git_dir = git_dir.strip()
+            if len(git_dir) >= 2 and git_dir[0] == git_dir[-1] and git_dir[0] in ('"', "'"):
+                git_dir = git_dir[1:-1]
+            if not os.path.isabs(git_dir):
+                git_dir = os.path.join(target_cwd, git_dir)
+            target_cwd = os.path.dirname(os.path.abspath(git_dir))
+        yield target_cwd
+
+
+def _changes_git_config(command):
+    """Identify Git command families that can write repository config."""
+    return any(_git_config_command_targets(command))
+
+
 def execute_command(cmd_string, cwd=None, shell=True):
     """Execute the system command at the specified address."""
+
+    for command_cwd in _git_config_command_targets(cmd_string, cwd):
+        if is_env_repository(command_cwd):
+            logging.warning('Refusing Git config mutation in the Env repository: %s', cmd_string)
+            return ''
 
     logging.debug('execute_command: %s' % cmd_string)
     sub = subprocess.Popen(cmd_string, cwd=cwd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=shell, bufsize=4096)
@@ -58,7 +186,7 @@ def is_windows():
 
 def git_pull_repo(repo_path, repo_url=''):
     try:
-        if is_windows():
+        if is_windows() and not is_env_repository(repo_path):
             cmd = r'git config --local core.autocrlf true'
             execute_command(cmd, cwd=repo_path)
         cmd = r'git pull ' + repo_url

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -40,8 +40,9 @@ org.example.demo-1.0.0-py3-none-any.epack
 ```
 
 `manifest.json` declares the plugin ID, name, version and compatibility, plus
-permissions and the applicable command, WebUI and backend artifact entries. A
-command entry uses `module.path:callable` syntax and implements:
+permissions and the applicable command, WebUI, health-check, service and
+backend artifact entries. A command entry uses `module.path:callable` syntax
+and implements:
 
 ```python
 def main(argv, context):
@@ -269,9 +270,9 @@ files under `frontend/`:
 }
 ```
 
-A WebUI-only plugin may omit `src/` and backend wheels. A plugin with commands
-or a health check must provide a backend artifact. After installation, start
-the local WebUI with:
+A WebUI-only plugin may omit `src/` and backend wheels. A plugin that declares
+commands, a health check, or a `service` must provide exactly one backend
+artifact with the `plugin` role. After installation, start the local WebUI with:
 
 ```bash
 webui start
@@ -297,11 +298,32 @@ and language through versioned `postMessage` messages. Pages cannot read host
 cookies or sessions, or call Env lifecycle APIs. See the complete
 [`build-insight` example](examples/build-insight-1.0.0/README.md).
 
+A plugin that needs a local HTTP or WebSocket backend may declare a `service`
+entry in its manifest. Env invokes the entry as `entry(context, host, port)`;
+`context` is a `RuntimeContext`, and the callable must return an ASGI
+application or an object with an `app` attribute:
+
+```python
+def create_service(context, host, port):
+    return app
+```
+
+The service starts on the first backend request. Env loads it in a supervised
+child process, checks `health_path`, binds it to a random loopback port, and
+proxies `/plugins/<id>/backend/` to it. Plugin asset pages may use the
+tokenized `/plugin-assets/<token>/<id>/backend/` equivalent returned by the
+WebUI session API. `health_path` must be an absolute safe HTTP path, and
+`start_timeout` must be an integer from 1 to 60 seconds. The service runner
+uses Uvicorn, so `uvicorn` and its runtime dependencies must be available as
+backend dependency wheels. The process is stopped when the plugin is disabled,
+upgraded, uninstalled, or the WebUI exits.
+
 ## Build and publishing notes
 
 - Command names in `manifest.json` must be unique and must not conflict with an existing system or plugin command.
 - `workspace.write` already includes read access; do not declare `workspace.read` with it.
 - If dependency wheels are declared, place them under the project `wheels/` directory at the paths listed in the manifest.
+- Service backends require `uvicorn` and its runtime dependencies to be included as dependency wheels.
 - Frontend resources must be prebuilt and must not contain source maps, symbolic links or path-traversal members.
 - V1 packages are currently unsigned local artifacts. Do not make `--yes` the default policy for packages from untrusted sources.
 - The WebUI shows the online catalog only when a market URL is configured. Installation still uses a one-time local upload id after the Host API downloads and inspects the artifact.

--- a/plugins/README.zh-CN.md
+++ b/plugins/README.zh-CN.md
@@ -32,7 +32,7 @@ org.example.demo-1.0.0-py3-none-any.epack
 └── backend/org_example_demo-1.0.0-py3-none-any.whl
 ```
 
-`manifest.json` 声明插件 ID、名称、版本和兼容性，并按插件能力声明权限、命令、WebUI 和后端 artifact。命令入口使用 `module.path:callable` 格式，并实现：
+`manifest.json` 声明插件 ID、名称、版本和兼容性，并按插件能力声明权限、命令、WebUI、健康检查、service 和后端制品。命令入口使用 `module.path:callable` 格式，并实现：
 
 ```python
 def main(argv, context):
@@ -230,13 +230,13 @@ WebUI 页面由 `manifest.webui` 声明，并以预构建静态资源放在 `fro
 }
 ```
 
-纯 WebUI 插件可以没有 `src/` 和后端 wheel；CLI 或健康检查存在时则必须提供后端 artifact。安装后启动本机 WebUI：
+纯 WebUI 插件可以没有 `src/` 和后端 wheel；声明命令、健康检查或 `service` 的插件必须提供且只能提供一个 `plugin` 角色的后端制品。安装后启动本机 WebUI：
 
 ```bash
 webui start
 ```
 
-`webui start` 会在后台启动本机服务，普通本地会话默认打开浏览器，打印启动 URL
+`webui start` 会在后台启动本机服务，在本地会话中默认打开浏览器，打印启动 URL
 后返回命令行。可以使用以下命令查询或停止服务：
 
 ```bash
@@ -251,11 +251,40 @@ webui stop
 
 插件页面运行在不带 `allow-same-origin` 的 iframe 中，宿主通过版本化 `postMessage` 传递主题和语言。页面不能读取宿主 Cookie、会话或直接调用 Env 生命周期 API。完整示例见 [`examples/build-insight-1.0.0/README.md`](examples/build-insight-1.0.0/README.md)。
 
+需要 HTTP 或 WebSocket 后端的插件可以在 `manifest.json` 声明 `service`：
+
+```json
+{
+  "service": {
+    "entry": "package.service:create_service",
+    "health_path": "/health",
+    "start_timeout": 15
+  }
+}
+```
+
+服务入口按 `entry(context, host, port)` 调用，其中 `context` 是
+`RuntimeContext`，返回值必须是 ASGI 应用，或带有 `app` 属性的对象：
+
+```python
+def create_service(context, host, port):
+    return app
+```
+
+首次访问后端路径时，Env 才会按需在独立子进程中启动服务，检查
+`health_path` 后将服务绑定到随机回环端口，并把
+`/plugins/<id>/backend/` 下的请求代理到服务。插件资源页也可以使用 WebUI
+会话接口返回的 `/plugin-assets/<token>/<id>/backend/` 路径。`health_path` 必须是
+安全的绝对 HTTP 路径，`start_timeout` 必须是 1 到 60 之间的整数。服务运行器使用
+Uvicorn，插件包必须通过 dependency wheel 提供 `uvicorn` 及其运行时依赖。插件禁用、
+升级、卸载或 WebUI 退出时，宿主会停止并回收服务进程。
+
 ## 构建和发布注意事项
 
 - `manifest.json` 中的命令名必须唯一，并且不能与系统已有命令或其他插件冲突。
 - `workspace.write` 已包含读取能力，不应同时声明 `workspace.read`。
 - 使用依赖 wheel 时，需要按清单路径把文件放在工程的 `wheels/` 目录中。
+- service 后端需要通过依赖 wheel 提供 `uvicorn` 及其运行时依赖。
 - 前端资源必须是预构建文件；不能包含 source map、符号链接或路径穿越成员。
 - v1 包目前是未签名的本地制品，不应将 `--yes` 作为不可信来源包的默认策略。
 - 仅在配置了市场地址时，WebUI 才显示在线插件目录。安装仍是 Host API 下载并检查后，使用一次性 upload id 交给本机安装器。

--- a/plugins/backend.py
+++ b/plugins/backend.py
@@ -1,0 +1,190 @@
+"""Lifecycle manager for plugin backend services."""
+
+import http.client
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from .compatibility import ensure_compatible
+from .errors import StateError, UsageError
+from .manifest import validate_manifest
+from .store import FileLock, StateStore
+
+
+class BackendUnavailableError(RuntimeError):
+    pass
+
+
+class BackendServiceManager(object):
+    def __init__(self, paths, store=None):
+        self.paths = paths
+        self.store = store or StateStore(paths)
+        self._lock = threading.RLock()
+        self._services = {}
+
+    def ensure(self, plugin_id, workspace):
+        workspace = os.path.abspath(workspace)
+        with self._lock:
+            current = self._services.get(plugin_id)
+            if current and current['workspace'] == workspace and current['process'].poll() is None:
+                return current['port']
+            if current:
+                self._stop_locked(plugin_id, current)
+            _record, manifest, install_dir, permissions = self._plugin(plugin_id)
+            if not manifest.service:
+                raise StateError('plugin does not provide a backend service: %s' % plugin_id)
+            if not os.path.isdir(workspace):
+                raise UsageError('backend workspace is not a directory: %s' % workspace)
+            port = _free_port()
+            runtime_dir = os.path.join(self.paths.runtime, plugin_id)
+            os.makedirs(runtime_dir, exist_ok=True)
+            log_path = os.path.join(runtime_dir, 'service.log')
+            site_packages = os.path.join(install_dir, 'site-packages')
+            module_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            environment = _service_environment(site_packages, module_root)
+            command = [
+                sys.executable,
+                '-m',
+                'plugins.service_runner',
+                '--entry',
+                manifest.service['entry'],
+                '--env-root',
+                self.paths.env_root,
+                '--plugin-id',
+                plugin_id,
+                '--version',
+                manifest.version,
+                '--permissions',
+                ','.join(sorted(permissions)),
+                '--workspace',
+                workspace,
+                '--host',
+                '127.0.0.1',
+                '--port',
+                str(port),
+            ]
+            log_file = open(log_path, 'ab')
+            try:
+                process = subprocess.Popen(
+                    command,
+                    cwd=install_dir,
+                    env=environment,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    close_fds=(os.name != 'nt'),
+                    creationflags=(getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0) if os.name == 'nt' else 0),
+                    start_new_session=(os.name != 'nt'),
+                )
+            except Exception:
+                log_file.close()
+                raise
+            log_file.close()
+            service = {'process': process, 'port': port, 'workspace': workspace, 'log': log_path}
+            self._services[plugin_id] = service
+            try:
+                _wait_health(process, port, manifest.service['health_path'], manifest.service['start_timeout'])
+            except BackendUnavailableError:
+                self._stop_locked(plugin_id, service)
+                self._services.pop(plugin_id, None)
+                raise
+            except Exception:
+                self._stop_locked(plugin_id, service)
+                self._services.pop(plugin_id, None)
+                raise BackendUnavailableError('plugin backend did not become ready')
+            return port
+
+    def stop(self, plugin_id):
+        with self._lock:
+            service = self._services.pop(plugin_id, None)
+            if service:
+                self._stop_locked(plugin_id, service)
+
+    def stop_all(self):
+        with self._lock:
+            services = list(self._services.items())
+            self._services.clear()
+            for plugin_id, service in services:
+                self._stop_locked(plugin_id, service)
+
+    def _stop_locked(self, plugin_id, service):
+        process = service['process']
+        if process.poll() is not None:
+            return
+        try:
+            if os.name == 'nt' and hasattr(process, 'send_signal'):
+                process.send_signal(getattr(signal, 'CTRL_BREAK_EVENT', 1))
+            else:
+                process.terminate()
+            process.wait(timeout=5)
+        except (OSError, subprocess.TimeoutExpired):
+            try:
+                process.kill()
+            except OSError:
+                pass
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
+
+    def _plugin(self, plugin_id):
+        with FileLock(self.paths.lock_file, shared=True):
+            state = self.store.load()
+        record = state['plugins'].get(plugin_id)
+        if record is None:
+            raise StateError('plugin is not installed: %s' % plugin_id)
+        if not record['enabled']:
+            raise StateError('plugin is disabled: %s' % plugin_id)
+        version = record['versions'].get(record['active_version'])
+        if version is None:
+            raise StateError('active plugin version is missing: %s' % plugin_id)
+        manifest = validate_manifest(version['manifest'])
+        ensure_compatible(manifest)
+        required = set(permission['name'] for permission in manifest.permissions if permission['required'])
+        granted = set(record['granted_permissions'])
+        missing = sorted(required - granted)
+        if missing:
+            raise StateError('required permissions are not granted: %s' % ', '.join(missing))
+        return record, manifest, self.paths.from_root(version['install_dir']), granted
+
+
+def _service_environment(site_packages, module_root):
+    environment = {}
+    for name in ('PATH', 'SYSTEMROOT', 'COMSPEC', 'PATHEXT', 'WINDIR', 'LANG', 'LC_ALL', 'TMP', 'TEMP', 'TMPDIR'):
+        if name in os.environ:
+            environment[name] = os.environ[name]
+    environment['PYTHONPATH'] = os.pathsep.join([site_packages, module_root])
+    return environment
+
+
+def _free_port():
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.bind(('127.0.0.1', 0))
+        return probe.getsockname()[1]
+    finally:
+        probe.close()
+
+
+def _wait_health(process, port, path, timeout):
+    deadline = time.monotonic() + timeout
+    last_error = 'service did not become ready'
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise BackendUnavailableError('plugin service exited with status %s' % process.returncode)
+        try:
+            connection = http.client.HTTPConnection('127.0.0.1', port, timeout=0.5)
+            connection.request('GET', path)
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+            if 200 <= response.status < 300:
+                return
+            last_error = 'health check returned HTTP %s' % response.status
+        except (OSError, http.client.HTTPException) as exc:
+            last_error = str(exc)
+        time.sleep(0.05)
+    raise BackendUnavailableError(last_error)

--- a/plugins/epack/project.py
+++ b/plugins/epack/project.py
@@ -220,7 +220,7 @@ def validate_project(directory):
     if not os.path.isfile(license_path) or os.path.getsize(license_path) == 0:
         raise PackageError("project requires a non-empty LICENSE file")
     source_root = os.path.join(directory, 'src')
-    requires_backend = bool(manifest.commands or manifest.health_check or manifest.artifacts)
+    requires_backend = bool(manifest.commands or manifest.health_check or manifest.service or manifest.artifacts)
     if requires_backend and not os.path.isdir(source_root):
         raise PackageError("project requires a src directory")
     for artifact in manifest.artifacts:
@@ -232,6 +232,8 @@ def validate_project(directory):
         _validate_source_entry(source_root, command['entry'])
     if manifest.health_check:
         _validate_source_entry(source_root, manifest.health_check)
+    if manifest.service:
+        _validate_source_entry(source_root, manifest.service['entry'])
     if os.path.isdir(source_root):
         _validate_resource_tree(source_root, 'plugin source')
     frontend_root = os.path.join(directory, 'frontend')

--- a/plugins/health_runner.py
+++ b/plugins/health_runner.py
@@ -39,6 +39,9 @@ def main(argv=None):
     for command in manifest['commands']:
         entry = _load_entry(command['entry'], os.path.abspath(site_packages))
         _accepts_command_abi(entry, command['entry'])
+    service = manifest.get('service')
+    if service:
+        _load_entry(service['entry'], os.path.abspath(site_packages))
     health_entry = manifest.get('health_check')
     if health_entry:
         result = _load_entry(health_entry, os.path.abspath(site_packages))()

--- a/plugins/installer.py
+++ b/plugins/installer.py
@@ -392,6 +392,7 @@ class PluginInstaller(object):
         manifest = active['manifest']
         result['commands'] = [command['name'] for command in manifest['commands']]
         result['webui'] = manifest.get('webui')
+        result['service'] = manifest.get('service')
         if details:
             result.update(
                 {

--- a/plugins/manifest.py
+++ b/plugins/manifest.py
@@ -148,6 +148,10 @@ class Manifest(object):
     def health_check(self):
         return self.data.get('health_check')
 
+    @property
+    def service(self):
+        return self.data.get('service')
+
     def to_dict(self):
         return json.loads(json.dumps(self.data, sort_keys=True))
 
@@ -173,7 +177,7 @@ def validate_manifest(data):
         'commands',
         'backend',
     ]
-    _keys(data, required, ['health_check', 'webui'], 'manifest')
+    _keys(data, required, ['health_check', 'service', 'webui'], 'manifest')
 
     if data['schema_version'] != SCHEMA_VERSION:
         raise ManifestError("unsupported manifest schema_version: %r" % data['schema_version'])
@@ -276,9 +280,9 @@ def validate_manifest(data):
             uses_pyc = artifact_format == 'pyc-wheel'
     if plugin_artifacts > 1:
         raise ManifestError("manifest.backend.artifacts can contain at most one plugin artifact")
-    requires_backend = bool(commands or data.get('health_check'))
+    requires_backend = bool(commands or data.get('health_check') or data.get('service'))
     if requires_backend and plugin_artifacts != 1:
-        raise ManifestError("commands and health_check require exactly one plugin artifact")
+        raise ManifestError("commands, health_check and service require exactly one plugin artifact")
     if artifacts and plugin_artifacts != 1:
         raise ManifestError("dependency artifacts require exactly one plugin artifact")
     if uses_pyc:
@@ -300,6 +304,22 @@ def validate_manifest(data):
         if not ENTRY_RE.match(health_check):
             raise ManifestError("manifest.health_check must use module.path:callable syntax")
 
+    if 'service' in data:
+        service = _object(data['service'], 'manifest.service')
+        _keys(service, ['entry', 'health_path', 'start_timeout'], [], 'manifest.service')
+        entry = _string(service['entry'], 'manifest.service.entry')
+        if not ENTRY_RE.match(entry):
+            raise ManifestError("manifest.service.entry must use module.path:callable syntax")
+        health_path = _string(service['health_path'], 'manifest.service.health_path')
+        if '\\' in health_path or ':' in health_path or not health_path.startswith('/'):
+            raise ManifestError("manifest.service.health_path must be an absolute HTTP path")
+        service_path = PurePosixPath(health_path)
+        if any(part in ('', '.', '..') for part in service_path.parts):
+            raise ManifestError("manifest.service.health_path contains an unsafe path component")
+        timeout = service['start_timeout']
+        if type(timeout) is not int or not 1 <= timeout <= 60:
+            raise ManifestError("manifest.service.start_timeout must be an integer between 1 and 60")
+
     if 'webui' in data:
         webui = _object(data['webui'], 'manifest.webui')
         _keys(webui, ['entry', 'icon', 'frontend_sdk'], [], 'manifest.webui')
@@ -319,7 +339,7 @@ def validate_manifest(data):
             raise ManifestError("manifest.webui.icon must be a lowercase icon identifier")
         _string(webui['frontend_sdk'], 'manifest.webui.frontend_sdk')
 
-    if not commands and 'webui' not in data and 'health_check' not in data:
+    if not commands and 'webui' not in data and 'health_check' not in data and 'service' not in data:
         raise ManifestError("manifest must declare a command, WebUI page or health_check")
 
     return Manifest(data)

--- a/plugins/package.py
+++ b/plugins/package.py
@@ -175,6 +175,7 @@ class EpackArchive(object):
             'permissions': list(self.manifest.permissions),
             'commands': list(self.manifest.commands),
             'backend': self.manifest.data['backend'],
+            'service': self.manifest.service,
             'webui': self.manifest.webui,
             'files': list(self._members),
             'signing_status': self.signing_status,

--- a/plugins/service.py
+++ b/plugins/service.py
@@ -1,6 +1,7 @@
-"""Shared service facade used by Env CLI and future WebUI adapters."""
+"""Shared plugin lifecycle facade for Env CLI and WebUI adapters."""
 
 from .installer import PluginInstaller
+from .backend import BackendServiceManager
 from .launchers import LauncherManager
 from .paths import PluginPaths
 from .store import StateStore
@@ -16,6 +17,7 @@ class PluginService(object):
             dispatcher_module=dispatcher_module,
         )
         self.installer = PluginInstaller(self.paths, launcher_manager=launchers, store=StateStore(self.paths))
+        self.backend = BackendServiceManager(self.paths, store=self.installer.store)
 
     def inspect_package(self, path):
         return self.installer.inspect(path).summary()
@@ -24,18 +26,24 @@ class PluginService(object):
         return self.installer.install(path, allow_unsigned=allow_unsigned, upgrade=False)
 
     def upgrade(self, path, allow_unsigned=False):
+        plugin_id = self._package_plugin_id(path)
+        if plugin_id:
+            self.stop_backend(plugin_id)
         return self.installer.install(path, allow_unsigned=allow_unsigned, upgrade=True)
 
     def uninstall(self, plugin_id, purge_data=False):
+        self.stop_backend(plugin_id)
         return self.installer.uninstall(plugin_id, purge_data=purge_data)
 
     def enable(self, plugin_id):
         return self.installer.set_enabled(plugin_id, True)
 
     def disable(self, plugin_id):
+        self.stop_backend(plugin_id)
         return self.installer.set_enabled(plugin_id, False)
 
     def set_permissions(self, plugin_id, permissions):
+        self.stop_backend(plugin_id)
         return self.installer.set_permissions(plugin_id, permissions)
 
     def list(self):
@@ -49,3 +57,18 @@ class PluginService(object):
 
     def resolve_webui_asset(self, plugin_id, asset_path=None):
         return self.installer.resolve_webui_asset(plugin_id, asset_path=asset_path)
+
+    def backend_port(self, plugin_id, workspace):
+        return self.backend.ensure(plugin_id, workspace)
+
+    def stop_backend(self, plugin_id):
+        self.backend.stop(plugin_id)
+
+    def stop_backends(self):
+        self.backend.stop_all()
+
+    def _package_plugin_id(self, path):
+        try:
+            return self.installer.inspect(path).manifest.plugin_id
+        except Exception:
+            return None

--- a/plugins/service_runner.py
+++ b/plugins/service_runner.py
@@ -1,0 +1,56 @@
+"""Run one installed plugin backend service in a supervised child process."""
+
+import argparse
+import importlib
+import sys
+
+from .paths import PluginPaths
+from .sdk.context import create_runtime_context
+
+
+def _load_entry(entry):
+    module_name, attribute = entry.split(':', 1)
+    module = importlib.import_module(module_name)
+    value = getattr(module, attribute, None)
+    if not callable(value):
+        raise TypeError('service entry is not callable: %s' % entry)
+    return value
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Run an Env plugin backend service')
+    parser.add_argument('--entry', required=True)
+    parser.add_argument('--env-root', required=True)
+    parser.add_argument('--plugin-id', required=True)
+    parser.add_argument('--version', required=True)
+    parser.add_argument('--permissions', default='')
+    parser.add_argument('--workspace', required=True)
+    parser.add_argument('--host', default='127.0.0.1')
+    parser.add_argument('--port', type=int, required=True)
+    args = parser.parse_args(argv)
+    paths = PluginPaths(env_root=args.env_root)
+    permissions = [item for item in args.permissions.split(',') if item]
+    context = create_runtime_context(
+        paths,
+        args.plugin_id,
+        args.version,
+        permissions,
+        workspace_root=args.workspace,
+    )
+    service = _load_entry(args.entry)(context, args.host, args.port)
+    app = getattr(service, 'app', service)
+    if app is None:
+        raise TypeError('service entry returned no ASGI application')
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise RuntimeError('plugin service requires uvicorn') from exc
+    uvicorn.run(app, host=args.host, port=args.port, log_level='warning')
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/plugins/spec/README.md
+++ b/plugins/spec/README.md
@@ -15,13 +15,13 @@ add constraints not expressible in the schema:
 
 - permission and command names must be unique;
 - `workspace.write` and `workspace.read` cannot both be declared;
-- commands and health checks require exactly one artifact with the `plugin` role;
+- commands, health checks and services require exactly one artifact with the `plugin` role;
 - WebUI-only plugins can omit backend artifacts, and CLI-only plugins can omit `webui`;
 - `source-wheel` uses a `py3` wheel tag;
 - `pyc-wheel` uses an exact declared CPython tag and matching bytecode magic;
-- command and health-check modules must load from the installed backend.
+- command, health-check and service entry modules must load from the installed backend;
 - `webui.entry` names an HTML file below `frontend/`, with no source maps or links;
-- a plugin declares at least one command, WebUI page, or health check.
+- a plugin declares at least one command, WebUI page, health check, or service.
 
 Plugin commands use this ABI:
 
@@ -45,6 +45,38 @@ Plugin WebUI declarations use this shape:
   }
 }
 ```
+
+Plugins that provide a long-running local HTTP/WebSocket backend may declare a
+supervised service:
+
+```json
+{
+  "service": {
+    "entry": "package.service:create_service",
+    "health_path": "/health",
+    "start_timeout": 15
+  }
+}
+```
+
+The entry is called as `entry(context, host, port)` in a child process. `context`
+is an `env.plugins.sdk.RuntimeContext`, and the callable must return an ASGI
+application (or an object with an `app` attribute):
+
+```python
+def create_service(context, host, port):
+    return app
+```
+
+Env starts the service on the first backend request, checks `health_path`, binds
+it to a random loopback port, and proxies requests from
+`/plugins/<id>/backend/`. Plugin asset pages may use the tokenized
+`/plugin-assets/<token>/<id>/backend/` equivalent returned by the WebUI session
+API. `health_path` must be an absolute safe HTTP path, and `start_timeout` must
+be an integer from 1 to 60 seconds. The service runner uses Uvicorn, so
+`uvicorn` and its runtime dependencies must be available as backend dependency
+wheels. The process is stopped when the plugin is disabled, upgraded,
+uninstalled, or the WebUI exits.
 
 Frontend files are prebuilt. Env installs them in the same version transaction
 as backend wheels and serves only the active, enabled, authorized version.

--- a/plugins/spec/manifest-v1.schema.json
+++ b/plugins/spec/manifest-v1.schema.json
@@ -241,6 +241,30 @@
       "type": "string",
       "pattern": "^[A-Za-z_][A-Za-z0-9_.]*:[A-Za-z_][A-Za-z0-9_]*$"
     },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entry",
+        "health_path",
+        "start_timeout"
+      ],
+      "properties": {
+        "entry": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_.]*:[A-Za-z_][A-Za-z0-9_]*$"
+        },
+        "health_path": {
+          "type": "string",
+          "pattern": "^/(?!.*(?:^|/)\\.\\.?/)[^:]*$"
+        },
+        "start_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 60
+        }
+      }
+    },
     "webui": {
       "type": "object",
       "additionalProperties": false,
@@ -268,6 +292,7 @@
   "anyOf": [
     {"properties": {"commands": {"minItems": 1}}},
     {"required": ["webui"]},
-    {"required": ["health_check"]}
+    {"required": ["health_check"]},
+    {"required": ["service"]}
   ]
 }

--- a/plugins/tests/test_manifest_package.py
+++ b/plugins/tests/test_manifest_package.py
@@ -59,6 +59,26 @@ class ManifestTest(unittest.TestCase):
         self.assertIn('architecture mips is not supported', issues)
         self.assertEqual(len(issues), 2, 'py3 source wheels should accept the current Python 3 ABI')
 
+    def test_service_manifest_is_validated_and_exposed(self):
+        data = json.loads(self.content.decode('utf-8'))
+        data['service'] = {
+            'entry': 'rt_env_plugin_hello.service:create_service',
+            'health_path': '/health',
+            'start_timeout': 10,
+        }
+        manifest = validate_manifest(data)
+        self.assertEqual(manifest.service['health_path'], '/health')
+
+    def test_service_manifest_rejects_unsafe_health_path(self):
+        data = json.loads(self.content.decode('utf-8'))
+        data['service'] = {
+            'entry': 'rt_env_plugin_hello.service:create_service',
+            'health_path': '/../health',
+            'start_timeout': 10,
+        }
+        with self.assertRaisesRegex(ManifestError, 'health_path'):
+            validate_manifest(data)
+
 
 class PackageTest(unittest.TestCase):
     def setUp(self):

--- a/plugins/tests/test_package_update_safety.py
+++ b/plugins/tests/test_package_update_safety.py
@@ -1,0 +1,150 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import vars
+from cmds.cmd_package import cmd_package_update
+from cmds.cmd_package import cmd_package_utils
+
+
+class _Package:
+    def __init__(self, url, repository):
+        self._url = url
+        self.pkg = {'repository': repository}
+
+    def get_url(self, version):
+        return self._url
+
+
+class PackageUpdateSafetyTest(unittest.TestCase):
+    def test_restore_url_does_not_convert_repository_homepage(self):
+        package = _Package(
+            'https://download.rt-thread.org/toolchain.tar.bz2',
+            'http://gcc.gnu.org',
+        )
+
+        self.assertIsNone(cmd_package_update._get_git_restore_url(package, 'latest'))
+
+    def test_restore_url_uses_version_specific_git_url(self):
+        package = _Package(
+            'https://github.com/example/package.git',
+            'https://example.invalid/package',
+        )
+
+        self.assertEqual(
+            'https://github.com/example/package.git',
+            cmd_package_update._get_git_restore_url(package, 'latest'),
+        )
+
+    def test_env_repository_config_mutations_are_refused(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            env_root = Path(temporary) / 'env'
+            child = env_root / 'packages' / 'package'
+            child.mkdir(parents=True)
+            subprocess.check_call(['git', 'init', '-q', str(env_root)])
+            subprocess.check_call(
+                ['git', '-C', str(env_root), 'remote', 'add', 'origin', 'https://example.invalid/env.git']
+            )
+
+            with mock.patch.dict(vars.env_vars, {'env_root': str(env_root)}, clear=False):
+                self.assertTrue(cmd_package_utils.is_env_repository(str(child)))
+                cmd_package_utils.execute_command(
+                    'git remote set-url origin http://gcc.gnu.org.git',
+                    cwd=str(child),
+                )
+
+            self.assertEqual(
+                'https://example.invalid/env.git',
+                subprocess.check_output(
+                    ['git', '-C', str(env_root), 'config', '--local', '--get', 'remote.origin.url'],
+                    universal_newlines=True,
+                ).strip(),
+            )
+
+    def test_gitee_package_remote_can_be_switched_for_prefetch(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            package_root = Path(temporary) / 'package'
+            package_root.mkdir()
+            subprocess.check_call(['git', 'init', '-q', str(package_root)])
+            subprocess.check_call(
+                ['git', '-C', str(package_root), 'remote', 'add', 'origin',
+                 'https://gitee.com/RT-Thread-Mirror/packages.git']
+            )
+
+            with mock.patch.dict(vars.env_vars, {'env_root': str(Path(temporary) / 'env')}, clear=False):
+                self.assertFalse(cmd_package_utils.is_env_repository(str(package_root)))
+                cmd_package_utils.execute_command(
+                    'git remote set-url origin https://github.com/RT-Thread/packages.git',
+                    cwd=str(package_root),
+                )
+
+            self.assertEqual(
+                'https://github.com/RT-Thread/packages.git',
+                subprocess.check_output(
+                    ['git', '-C', str(package_root), 'config', '--local', '--get', 'remote.origin.url'],
+                    universal_newlines=True,
+                ).strip(),
+            )
+
+    def test_git_c_repository_config_mutations_are_refused(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            env_root = Path(temporary) / 'env'
+            env_root.mkdir()
+            subprocess.check_call(['git', 'init', '-q', str(env_root)])
+            subprocess.check_call(
+                ['git', '-C', str(env_root), 'remote', 'add', 'origin', 'https://example.invalid/env.git']
+            )
+
+            with mock.patch.dict(vars.env_vars, {'env_root': str(env_root)}, clear=False):
+                cmd_package_utils.execute_command(
+                    'git -C "{}" remote set-url origin http://gcc.gnu.org.git'.format(env_root),
+                    cwd=temporary,
+                )
+
+            self.assertEqual(
+                'https://example.invalid/env.git',
+                subprocess.check_output(
+                    ['git', '-C', str(env_root), 'config', '--local', '--get', 'remote.origin.url'],
+                    universal_newlines=True,
+                ).strip(),
+            )
+
+    def test_relative_git_c_repository_config_mutations_are_refused(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            env_root = Path(temporary) / 'env'
+            env_root.mkdir()
+            subprocess.check_call(['git', 'init', '-q', str(env_root)])
+            subprocess.check_call(
+                ['git', '-C', str(env_root), 'remote', 'add', 'origin', 'https://example.invalid/env.git']
+            )
+
+            with mock.patch.dict(vars.env_vars, {'env_root': str(env_root)}, clear=False):
+                cmd_package_utils.execute_command(
+                    'git -C env remote set-url origin http://gcc.gnu.org.git',
+                    cwd=temporary,
+                )
+
+            self.assertEqual(
+                'https://example.invalid/env.git',
+                subprocess.check_output(
+                    ['git', '-C', str(env_root), 'config', '--local', '--get', 'remote.origin.url'],
+                    universal_newlines=True,
+                ).strip(),
+            )
+
+    def test_tools_scripts_repository_is_protected_by_env_root(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            env_root = Path(temporary) / 'env'
+            scripts_root = env_root / 'tools' / 'scripts'
+            child = scripts_root / 'packages' / 'package'
+            child.mkdir(parents=True)
+            subprocess.check_call(['git', 'init', '-q', str(scripts_root)])
+
+            with mock.patch.dict(vars.env_vars, {'env_root': str(env_root)}, clear=False):
+                self.assertTrue(cmd_package_utils.is_env_repository(str(child)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plugins/webui/server.py
+++ b/plugins/webui/server.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from http.cookies import SimpleCookie
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import hmac
+import http.client
 import ipaddress
 import json
 import mimetypes
@@ -15,6 +16,7 @@ import time
 from urllib.parse import parse_qs, unquote, urlparse
 
 from ..errors import PluginError, StateError, UsageError
+from ..backend import BackendUnavailableError
 from ..market import (
     MarketClient,
     MarketError,
@@ -278,6 +280,7 @@ class WebUIApplication(object):
                 pass
 
     def close(self):
+        self.service.stop_backends()
         with self.upload_lock:
             paths = [value[0] for value in self.uploads.values()]
             self.uploads.clear()
@@ -319,6 +322,9 @@ class EnvWebUIRequestHandler(BaseHTTPRequestHandler):
         self._dispatch('DELETE')
 
     def do_OPTIONS(self):
+        if self._valid_host() and self._is_backend_request(urlparse(self.path).path):
+            self._plugin_options()
+            return
         self._error(HTTPStatus.FORBIDDEN, 'cross_origin_denied', 'cross-origin requests are not allowed')
 
     def _dispatch(self, method):
@@ -330,11 +336,23 @@ class EnvWebUIRequestHandler(BaseHTTPRequestHandler):
             if parsed.path.startswith('/_launch/'):
                 self._launch(parsed.path)
                 return
-            if method == 'GET' and parsed.path.startswith('/plugin-assets/'):
+            if method == 'GET' and parsed.path.startswith('/plugin-assets/') and not self._is_tokenized_backend_request(parsed.path):
                 self._tokenized_plugin_asset(parsed.path)
                 return
             if not self.application.authenticated(self.headers.get('Cookie')):
                 self._error(HTTPStatus.UNAUTHORIZED, 'authentication_required', 'open the URL printed by env webui')
+                return
+            if method == 'GET' and self._is_backend_path(parsed.path) and self._is_websocket_request():
+                if not self._valid_plugin_origin():
+                    self._error(HTTPStatus.FORBIDDEN, 'origin_denied', 'WebSocket Origin is not allowed')
+                    return
+                self._plugin_websocket_proxy(parsed)
+                return
+            if self._is_backend_path(parsed.path) and self._is_backend_request(parsed.path):
+                if not self._valid_plugin_origin():
+                    self._error(HTTPStatus.FORBIDDEN, 'origin_denied', 'plugin request Origin is not allowed')
+                    return
+                self._plugin_http_proxy(method, parsed)
                 return
             if parsed.path.startswith('/api/'):
                 if method != 'GET' and not self._valid_write_request():
@@ -363,6 +381,8 @@ class EnvWebUIRequestHandler(BaseHTTPRequestHandler):
             self._error(status, exc.__class__.__name__.lower(), str(exc))
         except (ValueError, OSError) as exc:
             self._error(HTTPStatus.BAD_REQUEST, 'invalid_request', str(exc))
+        except BackendUnavailableError as exc:
+            self._error(HTTPStatus.BAD_GATEWAY, 'backend_unavailable', str(exc))
         except Exception:
             self._error(HTTPStatus.INTERNAL_SERVER_ERROR, 'internal_error', 'the WebUI request could not be completed')
 
@@ -450,6 +470,8 @@ class EnvWebUIRequestHandler(BaseHTTPRequestHandler):
                 body = self._read_json()
                 if set(body) != set(['enabled']) or not isinstance(body['enabled'], bool):
                     raise UsageError("enabled request must contain one boolean field")
+                if not body['enabled']:
+                    self.application.service.stop_backend(plugin_id)
                 operation = self.application.service.enable if body['enabled'] else self.application.service.disable
                 result = operation(plugin_id)
                 self._json(self.application._public_plugin(self.application.service.info(result['id'])))
@@ -465,6 +487,7 @@ class EnvWebUIRequestHandler(BaseHTTPRequestHandler):
                 purge = _first(query, 'purge_data', 'false').lower()
                 if purge not in ('true', 'false'):
                     raise UsageError("purge_data must be true or false")
+                self.application.service.stop_backend(plugin_id)
                 self._json(self.application.service.uninstall(plugin_id, purge_data=(purge == 'true')))
                 return
         self._error(HTTPStatus.NOT_FOUND, 'not_found', 'API endpoint was not found')
@@ -499,6 +522,134 @@ class EnvWebUIRequestHandler(BaseHTTPRequestHandler):
         asset = '/'.join(segments[2:]) or None
         target = self.application.service.resolve_webui_asset(plugin_id, asset)
         self._file(target, plugin=True)
+
+    def _is_backend_request(self, path):
+        segments = [item for item in path.split('/') if item]
+        return (
+            (len(segments) >= 3 and segments[0] == 'plugins' and segments[2] == 'backend')
+            or (len(segments) >= 5 and segments[0] == 'plugin-assets' and segments[3] == 'backend')
+        )
+
+    def _is_backend_path(self, path):
+        return path.startswith('/plugins/') or path.startswith('/plugin-assets/')
+
+    def _is_tokenized_backend_request(self, path):
+        return self._is_backend_request(path)
+
+    def _backend_target(self, parsed):
+        segments = [unquote(item) for item in parsed.path.split('/') if item]
+        if len(segments) >= 3 and segments[0] == 'plugins' and segments[2] == 'backend':
+            plugin_id = segments[1]
+            target_parts = segments[3:]
+        elif len(segments) >= 5 and segments[0] == 'plugin-assets' and segments[3] == 'backend':
+            if not hmac.compare_digest(segments[1], self.application.asset_token):
+                raise UsageError('invalid plugin backend path')
+            plugin_id = segments[2]
+            target_parts = segments[4:]
+        else:
+            raise UsageError('invalid plugin backend path')
+        if not target_parts:
+            raise UsageError('invalid plugin backend path')
+        target = '/' + '/'.join(target_parts)
+        if parsed.query:
+            target += '?' + parsed.query
+        port = self.application.service.backend_port(plugin_id, self.application.workspace)
+        return plugin_id, port, target
+
+    def _plugin_http_proxy(self, method, parsed):
+        _plugin_id, port, target = self._backend_target(parsed)
+        body = b''
+        if method in ('POST', 'PUT', 'DELETE'):
+            body = self._read_body(256 * 1024 * 1024) if self.headers.get('Content-Length') else b''
+        headers = {
+            'Host': '127.0.0.1:%d' % port,
+            'Accept': self.headers.get('Accept', '*/*'),
+            'User-Agent': self.headers.get('User-Agent', 'EnvWebUI/1.0'),
+        }
+        for name in ('Content-Type', 'Content-Length'):
+            value = self.headers.get(name)
+            if value:
+                headers[name] = value
+        connection = http.client.HTTPConnection('127.0.0.1', port, timeout=30)
+        try:
+            connection.request(method, target, body=body, headers=headers)
+            response = connection.getresponse()
+            content = response.read(256 * 1024 * 1024 + 1)
+        finally:
+            connection.close()
+        if len(content) > 256 * 1024 * 1024:
+            raise UsageError('backend response exceeds size limit')
+        self.send_response(response.status, response.reason)
+        for name, value in response.getheaders():
+            if name.lower() in ('connection', 'keep-alive', 'transfer-encoding', 'server', 'date'):
+                continue
+            self.send_header(name, value)
+        self.send_header('Content-Length', str(len(content)))
+        origin = self.headers.get('Origin')
+        if origin in ('null', 'http://%s' % self.headers.get('Host')):
+            self.send_header('Access-Control-Allow-Origin', origin)
+            self.send_header('Access-Control-Allow-Credentials', 'true')
+            self.send_header('Vary', 'Origin')
+        self.end_headers()
+        self.wfile.write(content)
+
+    def _plugin_options(self):
+        if not self._valid_plugin_origin():
+            self._error(HTTPStatus.FORBIDDEN, 'origin_denied', 'plugin request Origin is not allowed')
+            return
+        self.send_response(HTTPStatus.NO_CONTENT)
+        self.send_header('Access-Control-Allow-Origin', self.headers.get('Origin', 'null'))
+        self.send_header('Access-Control-Allow-Credentials', 'true')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', self.headers.get('Access-Control-Request-Headers', 'content-type'))
+        self.send_header('Access-Control-Max-Age', '300')
+        self.send_header('Vary', 'Origin')
+        self.end_headers()
+
+    def _is_websocket_request(self):
+        return self.headers.get('Upgrade', '').lower() == 'websocket'
+
+    def _valid_plugin_origin(self):
+        origin = self.headers.get('Origin', '')
+        expected = 'http://%s' % self.headers.get('Host')
+        return not origin or origin == 'null' or hmac.compare_digest(origin, expected)
+
+    def _plugin_websocket_proxy(self, parsed):
+        _plugin_id, port, target = self._backend_target(parsed)
+        upstream = socket.create_connection(('127.0.0.1', port), timeout=10)
+        upstream.settimeout(None)
+        key = self.headers.get('Sec-WebSocket-Key', '')
+        if not key:
+            upstream.close()
+            raise UsageError('WebSocket key is missing')
+        request = [
+            'GET %s HTTP/1.1' % target,
+            'Host: 127.0.0.1:%d' % port,
+            'Upgrade: websocket',
+            'Connection: Upgrade',
+            'Sec-WebSocket-Key: %s' % key,
+            'Sec-WebSocket-Version: %s' % self.headers.get('Sec-WebSocket-Version', '13'),
+            '',
+            '',
+        ]
+        upstream.sendall('\r\n'.join(request).encode('ascii'))
+        response = _read_http_headers(upstream)
+        if not response.startswith(b'HTTP/1.1 101') and not response.startswith(b'HTTP/1.0 101'):
+            upstream.close()
+            raise UsageError('backend WebSocket upgrade failed')
+        self.connection.sendall(response)
+        self.close_connection = True
+        client_to_backend = threading.Thread(target=_relay_stream, args=(self.connection, upstream), daemon=True)
+        backend_to_client = threading.Thread(target=_relay_stream, args=(upstream, self.connection), daemon=True)
+        client_to_backend.start()
+        backend_to_client.start()
+        client_to_backend.join()
+        try:
+            upstream.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        backend_to_client.join(timeout=5)
+        upstream.close()
 
     def _tokenized_plugin_asset(self, path):
         segments = [unquote(item) for item in path.split('/') if item]
@@ -543,8 +694,8 @@ class EnvWebUIRequestHandler(BaseHTTPRequestHandler):
             self.send_header(
                 'Content-Security-Policy',
                 "default-src 'none'; script-src %s; style-src %s 'unsafe-inline'; img-src %s data:; "
-                "connect-src 'none'; frame-ancestors %s; base-uri 'none'; form-action 'none'"
-                % (origin, origin, origin, origin),
+                "connect-src %s; frame-ancestors %s; base-uri 'none'; form-action 'none'"
+                % (origin, origin, origin, origin, origin),
             )
         else:
             self.send_header(
@@ -640,6 +791,33 @@ class EnvWebUIRequestHandler(BaseHTTPRequestHandler):
 def _first(query, name, default):
     values = query.get(name)
     return values[0] if values else default
+
+
+def _read_http_headers(connection):
+    content = b''
+    while b'\r\n\r\n' not in content and len(content) <= 64 * 1024:
+        chunk = connection.recv(4096)
+        if not chunk:
+            break
+        content += chunk
+    if b'\r\n\r\n' not in content:
+        raise UsageError('backend WebSocket response headers are invalid')
+    return content
+
+
+def _relay_stream(source, destination):
+    try:
+        while True:
+            chunk = source.read(65536) if hasattr(source, 'read') else source.recv(65536)
+            if not chunk:
+                break
+            if hasattr(destination, 'sendall'):
+                destination.sendall(chunk)
+            else:
+                destination.write(chunk)
+                destination.flush()
+    except (OSError, ValueError):
+        pass
 
 
 def _int_query(query, name, default, minimum, maximum):

--- a/touch_env.ps1
+++ b/touch_env.ps1
@@ -35,6 +35,8 @@ if (!(Test-Path -Path $env_dir)) {
     echo 'source "$PKGS_DIR/packages/Kconfig"' | Out-File -FilePath $env_dir/packages/Kconfig -Encoding ASCII
     git clone $SDK_URL $env_dir/packages/sdk --depth=1
     git clone $ENV_URL $env_dir/tools/scripts --depth=1
+    # Use the Gitee mirror for the initial download in China, then keep the
+    # canonical GitHub remotes for subsequent updates and metadata.
     git -C $env_dir/packages/packages remote set-url origin https://github.com/RT-Thread/packages.git
     git -C $env_dir/packages/sdk remote set-url origin https://github.com/RT-Thread/sdk.git
     git -C $env_dir/tools/scripts remote set-url origin https://github.com/RT-Thread/env.git

--- a/touch_env.sh
+++ b/touch_env.sh
@@ -28,6 +28,8 @@ if ! [ -d $env_dir ]; then
     echo 'source "$PKGS_DIR/packages/Kconfig"' >$env_dir/packages/Kconfig
     git clone $SDK_URL $env_dir/packages/sdk --depth=1
     git clone $ENV_URL $env_dir/tools/scripts --depth=1
+    # Use the Gitee mirror for the initial download in China, then keep the
+    # canonical GitHub remotes for subsequent updates and metadata.
     git -C $env_dir/packages/packages remote set-url origin https://github.com/RT-Thread/packages.git
     git -C $env_dir/packages/sdk remote set-url origin https://github.com/RT-Thread/sdk.git
     git -C $env_dir/tools/scripts remote set-url origin https://github.com/RT-Thread/env.git


### PR DESCRIPTION
- add plugin backend service lifecycle and service runner support
- extend plugin manifest validation and service-related metadata
- expose plugin service status and controls through the WebUI host
- protect the Env repository from unintended Git configuration changes during package updates
- preserve Gitee mirror prefetching and restoration of canonical remotes
- use explicit working directories for Git commands instead of changing the process directory
- add regression tests for Env repository protection and ordinary Gitee package remotes

## Validation

- `python -m unittest plugins.tests.test_package_update_safety`
- 7 tests passed
- `bash -n touch_env.sh`

## Compatibility

- ordinary package repositories can still temporarily switch `origin` to a Gitee mirror
- the original package Git URL is restored after the update
- only the Env repository itself is protected from package-update Git configuration mutations
- non-Git packages continue to use the existing download flow
