### PR TITLE
修复 WebUI 模块导入异常导致 BSP 包同步失败

### DIFF
--- a/plugins/tests/test_webui_server.py
+++ b/plugins/tests/test_webui_server.py
@@ -626,6 +626,45 @@ class WebUICommandTest(unittest.TestCase):
         init_logger.assert_called_once_with(env_module.get_env_root())
         webui_main.assert_called_once_with()
 
+    def test_installed_package_context_uses_env_manager_imports(self):
+        import importlib.util
+        import types
+
+        import file_context_menu
+        import plugins.backend
+        import plugins.errors
+        import plugins.market
+        import plugins.service
+        import plugins.webui
+        import sdk_manager
+        import toolchain_manager
+
+        package = types.ModuleType('env')
+        package.__path__ = [REPOSITORY]
+        aliases = {
+            'env': package,
+            'env.plugins': sys.modules['plugins'],
+            'env.plugins.backend': sys.modules['plugins.backend'],
+            'env.plugins.errors': sys.modules['plugins.errors'],
+            'env.plugins.market': sys.modules['plugins.market'],
+            'env.plugins.service': sys.modules['plugins.service'],
+            'env.plugins.webui': sys.modules['plugins.webui'],
+            'env.sdk_manager': sdk_manager,
+            'env.toolchain_manager': toolchain_manager,
+            'env.file_context_menu': file_context_menu,
+        }
+        with mock.patch.dict(sys.modules, aliases):
+            spec = importlib.util.spec_from_file_location(
+                'env.plugins.webui.server_test',
+                sys.modules['plugins.webui.server'].__file__,
+            )
+            imported = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(imported)
+
+        self.assertIs(imported.SdkManager, sdk_manager.SdkManager)
+        self.assertIs(imported.ToolchainManager, toolchain_manager.ToolchainManager)
+        self.assertIs(imported.FileContextMenuManager, file_context_menu.FileContextMenuManager)
+
     def test_standalone_help_uses_short_program_name(self):
         output = io.StringIO()
         with mock.patch('sys.stdout', new=output):

--- a/plugins/webui/server.py
+++ b/plugins/webui/server.py
@@ -29,11 +29,16 @@ from ..market import (
 )
 from ..service import PluginService
 from . import FRONTEND_SDK_VERSION, WEBUI_API_VERSION
-try:
+
+# The command-line compatibility entry point imports ``plugins`` as a
+# top-level package, while installed consumers import ``env.plugins``.
+# Select the matching manager imports explicitly instead of probing with a
+# relative import whose exception type differs between Python versions.
+if (__package__ or '').split('.', 1)[0] == 'env':
     from ...sdk_manager import SdkManager, SdkUsageError
     from ...toolchain_manager import ToolchainManager
     from ...file_context_menu import FileContextMenuManager
-except ImportError:
+else:
     from sdk_manager import SdkManager, SdkUsageError
     from toolchain_manager import ToolchainManager
     from file_context_menu import FileContextMenuManager


### PR DESCRIPTION
> ref：https://github.com/RT-Thread/rt-thread/actions/runs/33343867028/job/99357389700

修复 plugins/webui/server.py 在源码直跑和已安装包两种运行模式下的导入兼容问题。此前代码通过尝试三级相对导入并捕获 ImportError 判断导入路径，但部分 Python 版本会抛出 ValueError: attempted relative import beyond top-level package，导 致 pkgs --update-force 和 pkgs --list 在导入阶段直接失败，进而使 BSP 编译提示依赖包缺失。

现在根据 __package__ 显式区分 env.plugins.webui 和 plugins.webui 两种包上下文，分别使用相对导入和顶层导入，避免依赖异常类型判断。同时增加安装包上下文回归测试，验证 SDK、工具链和文件菜单管理器在两种导入模式下均可正常加载。相关 WebUI 测试和命令行入口验证已通过。